### PR TITLE
feat: FIN-08 — Componentes Input + Select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "personal-finance-app",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-select": "^2.2.6",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "next": "16.2.4",
@@ -1525,6 +1526,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -2470,6 +2509,502 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -3965,7 +4500,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3975,7 +4510,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4840,6 +5375,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -5662,7 +6209,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5847,6 +6394,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -7000,6 +7553,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -10008,6 +10570,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -11459,6 +12090,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@radix-ui/react-select": "^2.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "16.2.4",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,44 @@
 import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Select } from '@/components/ui/Select';
 
 export default function Home() {
   return (
     <>
+      <Button variant="primary">Placeholder</Button>
+      <Button variant="secondary">Placeholder</Button>
       <Button variant="tertiary">Placeholder</Button>
+      <Input label="Basic Field" placeholder="Placeholder" prefix="$" />
+      <Select
+        label="Category"
+        options={[
+          {
+            label: 'Latest',
+            value: 'latest',
+          },
+          {
+            label: 'Oldest',
+            value: 'oldest',
+          },
+          {
+            label: 'A to Z',
+            value: 'a-z',
+          },
+          {
+            label: 'Z to A',
+            value: 'z-a',
+          },
+          {
+            label: 'Highest',
+            value: 'highest',
+          },
+          {
+            label: 'Lowest',
+            value: 'lowest',
+          },
+        ]}
+        placeholder="Select a category"
+      />
     </>
   );
 }

--- a/src/components/ui/Input/Input.stories.tsx
+++ b/src/components/ui/Input/Input.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from './Input';
+
+const SearchIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M7.333 12.667A5.333 5.333 0 1 0 7.333 2a5.333 5.333 0 0 0 0 10.667ZM14 14l-2.9-2.9"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input',
+  component: Input,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: { default: 'light' },
+  },
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    error: { control: 'text' },
+    prefix: { control: 'text' },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    label: 'Transaction Name',
+    placeholder: 'e.g. Urban Services Hub',
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    label: 'Amount',
+    placeholder: '0.00',
+    helperText: 'Max $9999.99',
+  },
+};
+
+export const WithPrefix: Story = {
+  args: {
+    label: 'Amount',
+    prefix: '$',
+    placeholder: '0.00',
+    helperText: 'Max $9999.99',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    label: 'Search',
+    placeholder: 'Search transactions',
+    icon: <SearchIcon />,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: 'Transaction Name',
+    placeholder: 'e.g. Urban Services Hub',
+    error: 'This field is required',
+  },
+};
+
+export const ErrorWithPrefix: Story = {
+  args: {
+    label: 'Amount',
+    prefix: '$',
+    placeholder: '0.00',
+    error: 'Amount must be greater than 0',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Transaction Name',
+    placeholder: 'e.g. Urban Services Hub',
+    disabled: true,
+  },
+};
+
+export const DisabledWithPrefix: Story = {
+  args: {
+    label: 'Amount',
+    prefix: '$',
+    placeholder: '0.00',
+    disabled: true,
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '360px' }}>
+      <Input label="Default" placeholder="e.g. Urban Services Hub" />
+      <Input label="With Helper" placeholder="0.00" prefix="$" helperText="Max $9999.99" />
+      <Input label="With Icon" placeholder="Search transactions" icon={<SearchIcon />} />
+      <Input label="Error" placeholder="e.g. Urban Services Hub" error="This field is required" />
+      <Input label="Disabled" placeholder="e.g. Urban Services Hub" disabled />
+    </div>
+  ),
+};

--- a/src/components/ui/Input/Input.test.tsx
+++ b/src/components/ui/Input/Input.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Input } from './Input';
+
+describe('Input', () => {
+  it('renders without label', () => {
+    render(<Input placeholder="Enter value" />);
+    expect(screen.getByPlaceholderText('Enter value')).toBeInTheDocument();
+  });
+
+  it('renders label and associates it with input', () => {
+    render(<Input label="Amount" id="amount" />);
+    const label = screen.getByText('Amount');
+    const input = screen.getByLabelText('Amount');
+    expect(label).toBeInTheDocument();
+    expect(input).toBeInTheDocument();
+  });
+
+  it('generates id from label when id is not provided', () => {
+    render(<Input label="Transaction Name" />);
+    const input = screen.getByLabelText('Transaction Name');
+    expect(input).toHaveAttribute('id', 'transaction-name');
+  });
+
+  it('renders helper text', () => {
+    render(<Input label="Amount" helperText="Max $9999.99" />);
+    expect(screen.getByText('Max $9999.99')).toBeInTheDocument();
+  });
+
+  it('renders error message and sets aria-invalid', () => {
+    render(<Input label="Amount" error="This field is required" />);
+    const input = screen.getByLabelText('Amount');
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not render helper text when error is present', () => {
+    render(<Input label="Amount" helperText="Some hint" error="Required" />);
+    expect(screen.queryByText('Some hint')).not.toBeInTheDocument();
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  it('error message has role="alert"', () => {
+    render(<Input label="Amount" error="Required" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Required');
+  });
+
+  it('renders prefix text', () => {
+    render(<Input label="Amount" prefix="$" />);
+    expect(screen.getByText('$')).toBeInTheDocument();
+  });
+
+  it('renders icon', () => {
+    const icon = <svg data-testid="icon" />;
+    render(<Input label="Search" icon={icon} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('is disabled when disabled prop is passed', () => {
+    render(<Input label="Amount" disabled />);
+    expect(screen.getByLabelText('Amount')).toBeDisabled();
+  });
+
+  it('passes through native input props', () => {
+    render(<Input label="Amount" type="number" min={0} max={100} data-testid="input" />);
+    const input = screen.getByTestId('input');
+    expect(input).toHaveAttribute('type', 'number');
+    expect(input).toHaveAttribute('min', '0');
+    expect(input).toHaveAttribute('max', '100');
+  });
+
+  it('aria-describedby points to error id when error is present', () => {
+    render(<Input label="Amount" id="amount" error="Required" />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('aria-describedby', 'amount-error');
+  });
+
+  it('aria-describedby points to helper id when only helperText is present', () => {
+    render(<Input label="Amount" id="amount" helperText="Hint" />);
+    expect(screen.getByLabelText('Amount')).toHaveAttribute('aria-describedby', 'amount-helper');
+  });
+
+  it('applies border-red class when error is present', () => {
+    render(<Input label="Amount" error="Required" data-testid="input" />);
+    expect(screen.getByTestId('input')).toHaveClass('border-red');
+  });
+});

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -1,0 +1,92 @@
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
+  label?: string;
+  helperText?: string;
+  error?: string;
+  prefix?: string;
+  icon?: ReactNode;
+}
+
+export function Input({
+  label,
+  helperText,
+  error,
+  prefix,
+  icon,
+  id,
+  className,
+  disabled,
+  ...props
+}: InputProps) {
+  const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+  const hasError = Boolean(error);
+
+  return (
+    <div className="flex w-full flex-col gap-100">
+      {label && (
+        <label
+          htmlFor={inputId}
+          className={cn('text-preset-5-bold', disabled ? 'text-grey-500' : 'text-grey-500')}
+        >
+          {label}
+        </label>
+      )}
+      <div className="relative flex items-center">
+        {prefix && (
+          <span
+            aria-hidden="true"
+            className={cn(
+              'text-preset-4 pointer-events-none absolute left-300',
+              disabled ? 'text-grey-300' : 'text-beige-500'
+            )}
+          >
+            {prefix}
+          </span>
+        )}
+        <input
+          id={inputId}
+          disabled={disabled}
+          aria-invalid={hasError || undefined}
+          aria-describedby={
+            error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined
+          }
+          className={cn(
+            'text-preset-4 text-grey-900 w-full rounded-lg border bg-white px-300 py-300',
+            'placeholder:text-beige-500',
+            'transition-colors duration-150',
+            'focus:border-grey-900 focus:outline-none',
+            hasError ? 'border-red' : 'border-beige-500',
+            disabled && 'border-beige-500 cursor-not-allowed bg-white opacity-50',
+            prefix && 'pl-800',
+            icon && 'pr-800',
+            className
+          )}
+          {...props}
+        />
+        {icon && (
+          <span
+            aria-hidden="true"
+            className={cn(
+              'pointer-events-none absolute right-300',
+              disabled ? 'text-grey-300' : 'text-grey-500'
+            )}
+          >
+            {icon}
+          </span>
+        )}
+      </div>
+      {error && (
+        <span id={`${inputId}-error`} role="alert" className="text-preset-5 text-red text-right">
+          {error}
+        </span>
+      )}
+      {!error && helperText && (
+        <span id={`${inputId}-helper`} className="text-preset-5 text-grey-500 text-right">
+          {helperText}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Input/index.ts
+++ b/src/components/ui/Input/index.ts
@@ -1,0 +1,1 @@
+export { Input } from './Input';

--- a/src/components/ui/Select/Select.stories.tsx
+++ b/src/components/ui/Select/Select.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select } from './Select';
+import type { SelectOption } from './Select';
+
+const colorOptions: SelectOption[] = [
+  { value: 'green', label: 'Green', color: '#277c78' },
+  { value: 'yellow', label: 'Yellow', color: '#f2cdac' },
+  { value: 'cyan', label: 'Cyan', color: '#82c9d7' },
+  { value: 'navy', label: 'Navy', color: '#626070' },
+  { value: 'red', label: 'Red', color: '#c94736', alreadyUsed: true },
+  { value: 'purple', label: 'Purple', color: '#826cb0', alreadyUsed: true },
+  { value: 'turquoise', label: 'Turquoise', color: '#597c7c' },
+  { value: 'brown', label: 'Brown', color: '#93674f' },
+];
+
+const sortOptions: SelectOption[] = [
+  { value: 'latest', label: 'Latest' },
+  { value: 'oldest', label: 'Oldest' },
+  { value: 'a-z', label: 'A to Z' },
+  { value: 'z-a', label: 'Z to A' },
+  { value: 'highest', label: 'Highest' },
+  { value: 'lowest', label: 'Lowest' },
+];
+
+const meta: Meta<typeof Select> = {
+  title: 'UI/Select',
+  component: Select,
+  tags: ['autodocs'],
+  parameters: {
+    backgrounds: { default: 'light' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const Default: Story = {
+  args: {
+    label: 'Category',
+    placeholder: 'Select a category',
+    options: sortOptions,
+  },
+};
+
+export const WithColorDots: Story = {
+  args: {
+    label: 'Theme Color',
+    placeholder: 'Select a color',
+    options: colorOptions,
+  },
+};
+
+export const WithSelectedValue: Story = {
+  args: {
+    label: 'Theme Color',
+    options: colorOptions,
+    value: 'green',
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    label: 'Sort By',
+    placeholder: 'Select order',
+    options: sortOptions,
+    helperText: 'Affects the order of results',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    label: 'Category',
+    placeholder: 'Select a category',
+    options: sortOptions,
+    error: 'Please select a category',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Category',
+    placeholder: 'Select a category',
+    options: sortOptions,
+    disabled: true,
+  },
+};
+
+export const AllStates: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '360px' }}>
+      <Select label="Default" placeholder="Select an option" options={sortOptions} />
+      <Select label="With Color Dots" placeholder="Select a color" options={colorOptions} />
+      <Select label="With Value" options={colorOptions} value="green" />
+      <Select
+        label="Error"
+        placeholder="Select an option"
+        options={sortOptions}
+        error="This field is required"
+      />
+      <Select label="Disabled" placeholder="Select an option" options={sortOptions} disabled />
+    </div>
+  ),
+};

--- a/src/components/ui/Select/Select.test.tsx
+++ b/src/components/ui/Select/Select.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Select } from './Select';
+
+const options = [
+  { value: 'green', label: 'Green', color: '#277c78' },
+  { value: 'red', label: 'Red', color: '#c94736' },
+  { value: 'blue', label: 'Blue', color: '#3f82b2', alreadyUsed: true },
+];
+
+describe('Select', () => {
+  it('renders trigger with placeholder', () => {
+    render(<Select options={options} placeholder="Select a color" />);
+    expect(screen.getByText('Select a color')).toBeInTheDocument();
+  });
+
+  it('renders label and associates it with trigger', () => {
+    render(<Select label="Color" options={options} />);
+    expect(screen.getByText('Color')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders helper text', () => {
+    render(<Select options={options} helperText="Choose a theme color" />);
+    expect(screen.getByText('Choose a theme color')).toBeInTheDocument();
+  });
+
+  it('renders error and sets aria-invalid', () => {
+    render(<Select label="Color" id="color" options={options} error="Required" />);
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('error message has role="alert"', () => {
+    render(<Select options={options} error="Required" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Required');
+  });
+
+  it('does not render helper text when error is present', () => {
+    render(<Select options={options} helperText="Hint" error="Required" />);
+    expect(screen.queryByText('Hint')).not.toBeInTheDocument();
+  });
+
+  it('is disabled when disabled prop is passed', () => {
+    render(<Select options={options} disabled />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('opens dropdown and shows options on click', async () => {
+    render(<Select options={options} placeholder="Pick" />);
+    fireEvent.click(screen.getByRole('combobox'));
+    await waitFor(() => {
+      expect(screen.getByText('Green')).toBeInTheDocument();
+      expect(screen.getByText('Red')).toBeInTheDocument();
+      expect(screen.getByText('Blue')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onValueChange when an option is selected', async () => {
+    const onValueChange = vi.fn();
+    render(<Select options={options} placeholder="Pick" onValueChange={onValueChange} />);
+    fireEvent.click(screen.getByRole('combobox'));
+    await waitFor(() => screen.getByText('Green'));
+    fireEvent.click(screen.getByText('Green'));
+    expect(onValueChange).toHaveBeenCalledWith('green');
+  });
+
+  it('shows "Already used" badge for used options', async () => {
+    render(<Select options={options} placeholder="Pick" />);
+    fireEvent.click(screen.getByRole('combobox'));
+    await waitFor(() => screen.getByText('Already used'));
+    expect(screen.getByText('Already used')).toBeInTheDocument();
+  });
+
+  it('shows selected value in trigger', () => {
+    render(<Select options={options} value="green" />);
+    expect(screen.getByRole('combobox')).toHaveTextContent('Green');
+  });
+});

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import * as RadixSelect from '@radix-ui/react-select';
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/cn';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+  color?: string;
+  alreadyUsed?: boolean;
+}
+
+interface SelectProps {
+  label?: string;
+  helperText?: string;
+  error?: string;
+  placeholder?: string;
+  options: SelectOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  id?: string;
+  icon?: ReactNode;
+}
+
+function CaretDown() {
+  return (
+    <svg
+      width="11"
+      height="6"
+      viewBox="0 0 11 6"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M10.8541 0.85375L5.85414 5.85375C5.80771 5.90024 5.75256 5.93712 5.69186 5.96228C5.63117 5.98744 5.5661 6.00039 5.50039 6.00039C5.43469 6.00039 5.36962 5.98744 5.30892 5.96228C5.24822 5.93712 5.19308 5.90024 5.14664 5.85375L0.146644 0.85375C0.0766381 0.783823 0.0289543 0.694696 0.00962914 0.597654C-0.00969606 0.500611 0.000206247 0.400016 0.0380825 0.308605C0.0759587 0.217193 0.140106 0.139075 0.222403 0.08414C0.3047 0.0292046 0.401446 -7.77138e-05 0.500394 1.549e-07L10.5004 1.549e-07C10.5993 -7.77138e-05 10.6961 0.0292046 10.7784 0.08414C10.8607 0.139075 10.9248 0.217193 10.9627 0.308605C11.0006 0.400016 11.0105 0.500611 10.9912 0.597654C10.9718 0.694696 10.9241 0.783823 10.8541 0.85375Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M2 6L5 9L10 3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function Select({
+  label,
+  helperText,
+  error,
+  placeholder,
+  options,
+  value,
+  onValueChange,
+  disabled,
+  id,
+  icon,
+}: SelectProps) {
+  const selectId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
+  const hasError = Boolean(error);
+
+  return (
+    <div className="flex w-full flex-col gap-100">
+      {label && (
+        <label
+          htmlFor={selectId}
+          className={cn('text-preset-5-bold', disabled ? 'text-grey-300' : 'text-grey-500')}
+        >
+          {label}
+        </label>
+      )}
+      <RadixSelect.Root value={value} onValueChange={onValueChange} disabled={disabled}>
+        <RadixSelect.Trigger
+          id={selectId}
+          aria-invalid={hasError || undefined}
+          aria-describedby={
+            error ? `${selectId}-error` : helperText ? `${selectId}-helper` : undefined
+          }
+          className={cn(
+            'group flex w-full cursor-pointer items-center justify-between rounded-lg border bg-white px-300 py-300',
+            'text-preset-4 text-grey-900',
+            'transition-colors duration-150',
+            'focus:border-grey-900 focus:outline-none',
+            'data-[placeholder]:text-grey-500',
+            hasError ? 'border-red' : 'border-beige-500',
+            disabled && 'cursor-not-allowed opacity-50'
+          )}
+        >
+          <div className="flex items-center gap-200 overflow-hidden">
+            {icon && <span className="text-grey-500 shrink-0">{icon}</span>}
+            <RadixSelect.Value placeholder={placeholder} />
+          </div>
+          <RadixSelect.Icon className="text-grey-900 shrink-0 transition-transform duration-150 group-data-[state=open]:rotate-180">
+            <CaretDown />
+          </RadixSelect.Icon>
+        </RadixSelect.Trigger>
+
+        <RadixSelect.Portal>
+          <RadixSelect.Content
+            position="popper"
+            sideOffset={4}
+            className={cn(
+              'z-50 w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg bg-white shadow-lg',
+              'data-[state=open]:animate-in data-[state=closed]:animate-out',
+              'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+              'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95'
+            )}
+          >
+            <RadixSelect.Viewport className="py-100">
+              {options.map((option) => (
+                <RadixSelect.Item
+                  key={option.value}
+                  value={option.value}
+                  className={cn(
+                    'flex cursor-pointer items-center justify-between px-300 py-200 select-none',
+                    'text-preset-4 text-grey-900 outline-none',
+                    'border-grey-100 border-b last:border-b-0',
+                    'data-[state=checked]:font-bold',
+                    option.alreadyUsed && 'opacity-60'
+                  )}
+                >
+                  <div className="flex items-center gap-200">
+                    {option.color && (
+                      <span
+                        className="h-200 w-200 shrink-0 rounded-full"
+                        style={{ backgroundColor: option.color }}
+                        aria-hidden="true"
+                      />
+                    )}
+                    <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
+                  </div>
+                  <div className="flex items-center gap-200">
+                    {option.alreadyUsed && (
+                      <span className="text-preset-5 text-grey-500">Already used</span>
+                    )}
+                    <RadixSelect.ItemIndicator className="text-grey-900">
+                      <CheckIcon />
+                    </RadixSelect.ItemIndicator>
+                  </div>
+                </RadixSelect.Item>
+              ))}
+            </RadixSelect.Viewport>
+          </RadixSelect.Content>
+        </RadixSelect.Portal>
+      </RadixSelect.Root>
+
+      {error && (
+        <span id={`${selectId}-error`} role="alert" className="text-preset-5 text-red text-right">
+          {error}
+        </span>
+      )}
+      {!error && helperText && (
+        <span id={`${selectId}-helper`} className="text-preset-5 text-grey-500 text-right">
+          {helperText}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Select/index.ts
+++ b/src/components/ui/Select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from './Select';
+export type { SelectOption } from './Select';


### PR DESCRIPTION
## 📋 Description

- Add Input component with label, helper text, error state, prefix ($), and icon slot; wires aria-invalid and aria-describedby for accessibility
- Add Select component built on Radix UI with color dot per option, "Already used" badge, animated caret (rotates on open), and full keyboard navigation
- 25 tests covering all variants and states for both components
- Storybook stories with autodocs for both components

## 🔗 Related issue

Closes #7 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Run npm test — all 47 tests should pass
2. Run npm run storybook and open UI/Input — verify Default, WithPrefix, WithIcon, Error, and Disabled stories render correctly; check that the Docs page is generated
3. In the WithPrefix story, confirm the $ symbol appears inside the input on the left and the text has correct left padding
4. In the Error story, confirm the border turns red and the error message appears below the field
5. Open UI/Select — verify Default, WithColorDots, Error, and Disabled stories render correctly
6. In the WithColorDots story, click the trigger and confirm the dropdown matches the trigger width with no extra left spacing
7. Confirm the caret rotates 180° when the dropdown opens and returns on close
8. Confirm options with alreadyUsed: true show the "Already used" badge on the right and appear faded
9. Confirm the selected option shows a checkmark and bold text
10. Navigate the dropdown with keyboard (Tab to focus, Space/Enter to open, Arrow keys to navigate, Enter to select, Escape to close)

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [x] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)
<img width="1076" height="341" alt="Screenshot 2026-05-06 at 00 12 37" src="https://github.com/user-attachments/assets/ebfa208a-4392-4231-95aa-e0cdf92602fc" />
<img width="1076" height="535" alt="Screenshot 2026-05-06 at 00 12 44" src="https://github.com/user-attachments/assets/df8f9b8a-8253-4f3d-9bd4-34c7414ef8ee" />

