### PR TITLE
feat:  FIN-22 — Tela de cadastro

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,8 @@ const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
-  const isAuthPage = req.nextUrl.pathname.startsWith('/login');
+  const isAuthPage =
+    req.nextUrl.pathname.startsWith('/login') || req.nextUrl.pathname.startsWith('/signup');
 
   if (!isLoggedIn && !isAuthPage) {
     return NextResponse.redirect(new URL('/login', req.nextUrl.origin));

--- a/src/app/(auth)/login/LoginForm.test.tsx
+++ b/src/app/(auth)/login/LoginForm.test.tsx
@@ -60,9 +60,9 @@ describe('LoginForm', () => {
       expect(screen.getByRole('button', { name: /github/i })).toBeInTheDocument();
     });
 
-    it('renders the sign up link pointing to /register', () => {
+    it('renders the sign up link pointing to /signup', () => {
       render(<LoginForm />);
-      expect(screen.getByRole('link', { name: 'Sign Up' })).toHaveAttribute('href', '/register');
+      expect(screen.getByRole('link', { name: 'Sign Up' })).toHaveAttribute('href', '/signup');
     });
   });
 

--- a/src/app/(auth)/login/LoginForm.tsx
+++ b/src/app/(auth)/login/LoginForm.tsx
@@ -13,7 +13,7 @@ import { GitHubIcon } from '@/components/ui/icons/GitHubIcon';
 import { loginWithCredentials, loginWithGitHub } from './actions';
 
 const schema = z.object({
-  email: z.string().email({ message: 'Please enter a valid email.' }),
+  email: z.string().check(z.email({ message: 'Please enter a valid email.' })),
   password: z.string().min(1, { message: 'Password is required.' }),
 });
 

--- a/src/app/(auth)/signup/SignUpForm.test.tsx
+++ b/src/app/(auth)/signup/SignUpForm.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignUpForm } from './SignUpForm';
+import * as actions from './actions';
+
+vi.mock('./actions', () => ({
+  signUpWithCredentials: vi.fn(),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockSignUp = vi.mocked(actions.signUpWithCredentials);
+
+const VALID_NAME = 'Jane Doe';
+const VALID_EMAIL = 'jane@example.com';
+const VALID_PASSWORD = 'secret123';
+
+async function fillAndSubmit(name = VALID_NAME, email = VALID_EMAIL, password = VALID_PASSWORD) {
+  await userEvent.type(screen.getByLabelText('Name'), name);
+  await userEvent.type(screen.getByLabelText('Email'), email);
+  await userEvent.type(screen.getByLabelText('Create Password'), password);
+  await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+}
+
+describe('SignUpForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignUp.mockResolvedValue(undefined);
+  });
+
+  describe('rendering', () => {
+    it('renders the sign up heading', () => {
+      render(<SignUpForm />);
+      expect(screen.getByRole('heading', { name: 'Sign Up' })).toBeInTheDocument();
+    });
+
+    it('renders name, email and password fields', () => {
+      render(<SignUpForm />);
+      expect(screen.getByLabelText('Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Email')).toBeInTheDocument();
+      expect(screen.getByLabelText('Create Password')).toBeInTheDocument();
+    });
+
+    it('renders the create account submit button', () => {
+      render(<SignUpForm />);
+      expect(screen.getByRole('button', { name: 'Create Account' })).toBeInTheDocument();
+    });
+
+    it('renders the login link pointing to /login', () => {
+      render(<SignUpForm />);
+      expect(screen.getByRole('link', { name: 'Login' })).toHaveAttribute('href', '/login');
+    });
+
+    it('shows the password helper text by default', () => {
+      render(<SignUpForm />);
+      expect(screen.getByText('Passwords must be at least 8 characters.')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('name field has aria-required', () => {
+      render(<SignUpForm />);
+      expect(screen.getByLabelText('Name')).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('email field has aria-required', () => {
+      render(<SignUpForm />);
+      expect(screen.getByLabelText('Email')).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('password field has aria-required', () => {
+      render(<SignUpForm />);
+      expect(screen.getByLabelText('Create Password')).toHaveAttribute('aria-required', 'true');
+    });
+
+    it('email field has type email', () => {
+      render(<SignUpForm />);
+      expect(screen.getByLabelText('Email')).toHaveAttribute('type', 'email');
+    });
+
+    it('password toggle has a descriptive aria-label', () => {
+      render(<SignUpForm />);
+      expect(screen.getByRole('button', { name: 'Show password' })).toBeInTheDocument();
+    });
+
+    it('server error uses role alert', async () => {
+      mockSignUp.mockResolvedValue({ error: 'An account with this email already exists.' });
+      render(<SignUpForm />);
+      await fillAndSubmit();
+      expect(await screen.findByRole('alert')).toBeInTheDocument();
+    });
+
+    it('validation errors use role alert', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      const alerts = await screen.findAllByRole('alert');
+      expect(alerts.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('password toggle', () => {
+    it('renders password field as type password by default', () => {
+      render(<SignUpForm />);
+      expect(screen.getByLabelText('Create Password')).toHaveAttribute('type', 'password');
+    });
+
+    it('shows password when toggle is clicked', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Show password' }));
+      expect(screen.getByLabelText('Create Password')).toHaveAttribute('type', 'text');
+    });
+
+    it('updates toggle aria-label after reveal', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Show password' }));
+      expect(screen.getByRole('button', { name: 'Hide password' })).toBeInTheDocument();
+    });
+
+    it('hides password again on second click', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Show password' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Hide password' }));
+      expect(screen.getByLabelText('Create Password')).toHaveAttribute('type', 'password');
+    });
+  });
+
+  describe('validation', () => {
+    it('shows error when name is empty on submit', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      expect(await screen.findByText('Name is required.')).toBeInTheDocument();
+    });
+
+    it('shows error for empty email on submit', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      expect(await screen.findByText('Please enter a valid email.')).toBeInTheDocument();
+    });
+
+    it('shows error for malformed email', async () => {
+      render(<SignUpForm />);
+      await userEvent.type(screen.getByLabelText('Email'), 'notanemail');
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      expect(await screen.findByText('Please enter a valid email.')).toBeInTheDocument();
+    });
+
+    it('shows error for password shorter than 8 characters', async () => {
+      render(<SignUpForm />);
+      await userEvent.type(screen.getByLabelText('Name'), VALID_NAME);
+      await userEvent.type(screen.getByLabelText('Email'), VALID_EMAIL);
+      await userEvent.type(screen.getByLabelText('Create Password'), 'short');
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      expect(
+        await screen.findByText('Password must be at least 8 characters.')
+      ).toBeInTheDocument();
+    });
+
+    it('hides helper text and shows error when password is too short', async () => {
+      render(<SignUpForm />);
+      await userEvent.type(screen.getByLabelText('Create Password'), 'short');
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      await screen.findByText('Password must be at least 8 characters.');
+      expect(
+        screen.queryByText('Passwords must be at least 8 characters.')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not call signUpWithCredentials when form is invalid', async () => {
+      render(<SignUpForm />);
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      expect(mockSignUp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submission', () => {
+    it('calls signUpWithCredentials with name, email and password', async () => {
+      render(<SignUpForm />);
+      await fillAndSubmit();
+      await waitFor(() => {
+        expect(mockSignUp).toHaveBeenCalledWith(VALID_NAME, VALID_EMAIL, VALID_PASSWORD);
+      });
+    });
+
+    it('calls signUpWithCredentials exactly once per submit', async () => {
+      render(<SignUpForm />);
+      await fillAndSubmit();
+      await waitFor(() => {
+        expect(mockSignUp).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('shows server error when email is already registered', async () => {
+      mockSignUp.mockResolvedValue({ error: 'An account with this email already exists.' });
+      render(<SignUpForm />);
+      await fillAndSubmit();
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'An account with this email already exists.'
+      );
+    });
+
+    it('clears server error before each new submission', async () => {
+      mockSignUp
+        .mockResolvedValueOnce({ error: 'An account with this email already exists.' })
+        .mockResolvedValueOnce(undefined);
+
+      render(<SignUpForm />);
+      await fillAndSubmit();
+      await screen.findByRole('alert');
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+      await waitFor(() => {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/app/(auth)/signup/SignUpForm.tsx
+++ b/src/app/(auth)/signup/SignUpForm.tsx
@@ -35,9 +35,13 @@ export function SignUpForm() {
   function onSubmit(data: FormValues) {
     setServerError(null);
     startTransition(async () => {
-      const result = await signUpWithCredentials(data.name, data.email, data.password);
-      if (result?.error) {
-        setServerError(result.error);
+      try {
+        const result = await signUpWithCredentials(data.name, data.email, data.password);
+        if (result?.error) {
+          setServerError(result.error);
+        }
+      } catch {
+        setServerError('Something went wrong. Please try again.');
       }
     });
   }

--- a/src/app/(auth)/signup/SignUpForm.tsx
+++ b/src/app/(auth)/signup/SignUpForm.tsx
@@ -13,7 +13,7 @@ import { signUpWithCredentials } from './actions';
 
 const schema = z.object({
   name: z.string().min(1, { message: 'Name is required.' }),
-  email: z.string().email({ message: 'Please enter a valid email.' }),
+  email: z.string().check(z.email({ message: 'Please enter a valid email.' })),
   password: z.string().min(8, { message: 'Password must be at least 8 characters.' }),
 });
 
@@ -30,6 +30,7 @@ export function SignUpForm() {
     formState: { errors },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
+    mode: 'onBlur',
   });
 
   function onSubmit(data: FormValues) {

--- a/src/app/(auth)/signup/SignUpForm.tsx
+++ b/src/app/(auth)/signup/SignUpForm.tsx
@@ -9,17 +9,17 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { EyeIcon } from '@/components/ui/icons/EyeIcon';
 import { EyeOffIcon } from '@/components/ui/icons/EyeOffIcon';
-import { GitHubIcon } from '@/components/ui/icons/GitHubIcon';
-import { loginWithCredentials, loginWithGitHub } from './actions';
+import { signUpWithCredentials } from './actions';
 
 const schema = z.object({
+  name: z.string().min(1, { message: 'Name is required.' }),
   email: z.string().email({ message: 'Please enter a valid email.' }),
-  password: z.string().min(1, { message: 'Password is required.' }),
+  password: z.string().min(8, { message: 'Password must be at least 8 characters.' }),
 });
 
 type FormValues = z.infer<typeof schema>;
 
-export function LoginForm() {
+export function SignUpForm() {
   const [isPending, startTransition] = useTransition();
   const [serverError, setServerError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
@@ -35,7 +35,7 @@ export function LoginForm() {
   function onSubmit(data: FormValues) {
     setServerError(null);
     startTransition(async () => {
-      const result = await loginWithCredentials(data.email, data.password);
+      const result = await signUpWithCredentials(data.name, data.email, data.password);
       if (result?.error) {
         setServerError(result.error);
       }
@@ -44,24 +44,40 @@ export function LoginForm() {
 
   return (
     <div className="flex flex-col gap-500">
-      <h1 className="text-preset-1 text-grey-900">Login</h1>
+      <h1 className="text-preset-1 text-grey-900">Sign Up</h1>
 
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-400" noValidate>
+        <Input
+          label="Name"
+          type="text"
+          placeholder="Your name"
+          autoComplete="name"
+          required
+          aria-required="true"
+          error={errors.name?.message}
+          {...register('name')}
+        />
+
         <Input
           label="Email"
           type="email"
           placeholder="you@example.com"
           autoComplete="email"
+          required
+          aria-required="true"
           error={errors.email?.message}
           {...register('email')}
         />
 
         <Input
-          label="Password"
+          label="Create Password"
           type={showPassword ? 'text' : 'password'}
           placeholder="••••••••"
-          autoComplete="current-password"
+          autoComplete="new-password"
+          required
+          aria-required="true"
           error={errors.password?.message}
+          helperText={errors.password ? undefined : 'Passwords must be at least 8 characters.'}
           icon={
             <button
               type="button"
@@ -82,30 +98,17 @@ export function LoginForm() {
         )}
 
         <Button type="submit" loading={isPending} className="mt-100">
-          Login
-        </Button>
-      </form>
-
-      <div className="flex items-center gap-300">
-        <div className="bg-grey-300 h-px flex-1" />
-        <span className="text-preset-5 text-grey-500">or</span>
-        <div className="bg-grey-300 h-px flex-1" />
-      </div>
-
-      <form action={loginWithGitHub}>
-        <Button type="submit" variant="secondary">
-          <GitHubIcon />
-          Continue with GitHub
+          Create Account
         </Button>
       </form>
 
       <p className="text-preset-4 text-grey-500 text-center">
-        Need to create an account?{' '}
+        Already have an account?{' '}
         <Link
-          href="/signup"
+          href="/login"
           className="text-preset-4-bold text-grey-900 underline underline-offset-2"
         >
-          Sign Up
+          Login
         </Link>
       </p>
     </div>

--- a/src/app/(auth)/signup/actions.ts
+++ b/src/app/(auth)/signup/actions.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import { AuthError } from 'next-auth';
+import { hash } from 'bcryptjs';
+import { signIn } from '@/lib/auth/auth';
+import { prisma } from '@/lib/db/prisma';
+
+export async function signUpWithCredentials(
+  name: string,
+  email: string,
+  password: string
+): Promise<{ error: string } | undefined> {
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return { error: 'An account with this email already exists.' };
+  }
+
+  const passwordHash = await hash(password, 12);
+  await prisma.user.create({ data: { name, email, passwordHash } });
+
+  try {
+    await signIn('credentials', { email, password, redirectTo: '/' });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return { error: 'Account created but sign-in failed. Please log in.' };
+    }
+    throw error;
+  }
+}

--- a/src/app/(auth)/signup/actions.ts
+++ b/src/app/(auth)/signup/actions.ts
@@ -2,6 +2,7 @@
 
 import { AuthError } from 'next-auth';
 import { hash } from 'bcryptjs';
+import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { signIn } from '@/lib/auth/auth';
 import { prisma } from '@/lib/db/prisma';
 
@@ -10,20 +11,21 @@ export async function signUpWithCredentials(
   email: string,
   password: string
 ): Promise<{ error: string } | undefined> {
-  const existing = await prisma.user.findUnique({ where: { email } });
-  if (existing) {
-    return { error: 'An account with this email already exists.' };
-  }
-
-  const passwordHash = await hash(password, 12);
-  await prisma.user.create({ data: { name, email, passwordHash } });
-
   try {
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return { error: 'An account with this email already exists.' };
+    }
+
+    const passwordHash = await hash(password, 12);
+    await prisma.user.create({ data: { name, email, passwordHash } });
+
     await signIn('credentials', { email, password, redirectTo: '/' });
   } catch (error) {
+    if (isRedirectError(error)) throw error;
     if (error instanceof AuthError) {
       return { error: 'Account created but sign-in failed. Please log in.' };
     }
-    throw error;
+    return { error: 'Something went wrong. Please try again.' };
   }
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,0 +1,40 @@
+import Image from 'next/image';
+import { SignUpForm } from './SignUpForm';
+
+export default function SignUpPage() {
+  return (
+    <main className="bg-beige-100 flex min-h-screen items-center justify-center p-500">
+      <div className="grid w-full max-w-[75rem] grid-cols-2 items-center gap-[140]">
+        {/* Left panel — taller than the form card */}
+        <div
+          className="hidden h-[40rem] flex-1 flex-col justify-between overflow-hidden rounded-2xl p-600 lg:flex"
+          style={{
+            backgroundImage: 'url(/images/login-illustration.svg)',
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+          }}
+        >
+          <Image src="/images/logo.png" alt="finance" width={120} height={22} />
+
+          <div className="space-y-300">
+            <h2 className="text-preset-1 text-white">
+              Keep track of your money
+              <br />
+              and save for your future
+            </h2>
+            <p className="text-preset-4 text-white">
+              Personal finance app puts you in control of your spending. Track transactions, set
+              budgets, and add to savings pots easily.
+            </p>
+          </div>
+        </div>
+
+        {/* Right panel — form card */}
+        <div className="w-full shrink-0 rounded-2xl bg-white px-500 py-600 shadow-2xl">
+          <SignUpForm />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

- Implements the Sign Up screen (/signup) following the same two-column layout as the Login page — illustration panel on the left, form card on the right
- Adds a server action that checks for duplicate emails, hashes the password with bcrypt and persists the user to Prisma, then auto signs-in and redirects to /
- Extends the middleware to treat /signup as a public auth page so unauthenticated users can reach it
- Fixes the deprecated Zod v4 .email() call in both forms (z.string().check(z.email()))

## 🔗 Related issue

Closes #17 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Visit /signup while logged in → should redirect to /
2. Visit /signup while logged out → should display the sign up page normally
3. Leave the Name field empty and click away → "Name is required." error should appear on blur
4. Type an invalid email (e.g. test) in the Email field and click away → "Please enter a valid email." error should appear on blur
5. Type a password shorter than 8 characters and click away → "Password must be at least 8 characters." error should appear and the helper text "Passwords must be at least 8 characters." should disappear
6. Fill in Name, an unregistered email, and a password with 8+ characters
7. Click "Create Account" → button should enter a loading state
8. After sign up, should automatically redirect to /
9. Confirm in Neon (or local DB) that the user was created with passwordHash populated


## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [x] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1437" height="829" alt="Screenshot 2026-05-06 at 23 06 14" src="https://github.com/user-attachments/assets/199de191-dd5c-4f0f-8cdd-74a36dae87fa" />
