### PR TITLE
feat: FIN-31 — Bottom navigation mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/Card";
 import { Dialog, DialogClose } from "@/components/ui/Dialog";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
+import { BottomNav } from "@/components/ui/BottomNav";
 import { Sidebar } from "@/components/ui/Sidebar";
 
 export default async function Home() {
@@ -14,7 +15,8 @@ export default async function Home() {
   return (
     <div className="flex gap-1000">
       <Sidebar />
-      <main className="grid w-full gap-300 p-400">
+      <BottomNav />
+      <main className="grid w-full gap-300 p-400 pb-24 lg:pb-400">
         <form
           action={async () => {
             "use server";

--- a/src/components/ui/BottomNav/BottomNav.test.tsx
+++ b/src/components/ui/BottomNav/BottomNav.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BottomNav } from "./BottomNav";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+import { usePathname } from "next/navigation";
+
+const mockUsePathname = vi.mocked(usePathname);
+
+describe("BottomNav", () => {
+  describe("rendering", () => {
+    it("renders all 5 nav links", () => {
+      mockUsePathname.mockReturnValue("/");
+      render(<BottomNav />);
+
+      expect(
+        screen.getByRole("link", { name: /overview/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /transactions/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /budgets/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /pots/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /bills/i })).toBeInTheDocument();
+    });
+
+    it("renders with accessible nav label", () => {
+      mockUsePathname.mockReturnValue("/");
+      render(<BottomNav />);
+
+      expect(
+        screen.getByRole("navigation", { name: /main navigation/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("all links have aria-label", () => {
+      mockUsePathname.mockReturnValue("/");
+      render(<BottomNav />);
+
+      const links = screen.getAllByRole("link");
+      links.forEach((link) => {
+        expect(link).toHaveAttribute("aria-label");
+      });
+    });
+  });
+
+  describe("active state", () => {
+    it("sets aria-current='page' on the active link", () => {
+      mockUsePathname.mockReturnValue("/budgets");
+      render(<BottomNav />);
+
+      expect(screen.getByRole("link", { name: /budgets/i })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    });
+
+    it("does not set aria-current on inactive links", () => {
+      mockUsePathname.mockReturnValue("/budgets");
+      render(<BottomNav />);
+
+      expect(
+        screen.getByRole("link", { name: /overview/i }),
+      ).not.toHaveAttribute("aria-current");
+      expect(screen.getByRole("link", { name: /pots/i })).not.toHaveAttribute(
+        "aria-current",
+      );
+    });
+
+    it("applies active background class to the active item", () => {
+      mockUsePathname.mockReturnValue("/transactions");
+      render(<BottomNav />);
+
+      const activeLink = screen.getByRole("link", { name: /transactions/i });
+      const pill = activeLink.querySelector("span");
+      expect(pill).toHaveClass("bg-beige-100");
+    });
+
+    it("does not apply active background to inactive items", () => {
+      mockUsePathname.mockReturnValue("/transactions");
+      render(<BottomNav />);
+
+      const inactiveLink = screen.getByRole("link", { name: /pots/i });
+      const pill = inactiveLink.querySelector("span");
+      expect(pill).not.toHaveClass("bg-beige-100");
+    });
+
+    it("has only one active link at a time", () => {
+      mockUsePathname.mockReturnValue("/pots");
+      render(<BottomNav />);
+
+      const activeLinks = screen
+        .getAllByRole("link")
+        .filter((link) => link.getAttribute("aria-current") === "page");
+
+      expect(activeLinks).toHaveLength(1);
+    });
+
+    it("marks overview as active on root path", () => {
+      mockUsePathname.mockReturnValue("/");
+      render(<BottomNav />);
+
+      expect(screen.getByRole("link", { name: /overview/i })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    });
+
+    it("marks bills as active on recurring-bills route", () => {
+      mockUsePathname.mockReturnValue("/recurring-bills");
+      render(<BottomNav />);
+
+      expect(screen.getByRole("link", { name: /bills/i })).toHaveAttribute(
+        "aria-current",
+        "page",
+      );
+    });
+  });
+});

--- a/src/components/ui/BottomNav/BottomNav.tsx
+++ b/src/components/ui/BottomNav/BottomNav.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/cn";
+import { BudgetsIcon } from "../icons/BudgetsIcon";
+import { OverviewIcon } from "../icons/OverviewIcon";
+import { PotsIcon } from "../icons/PotsIcon";
+import { RecurringBillsIcon } from "../icons/RecurringBillsIcon";
+import { TransactionsIcon } from "../icons/TransactionsIcon";
+
+const navItems = [
+  { href: "/", label: "Overview", Icon: OverviewIcon },
+  { href: "/transactions", label: "Transactions", Icon: TransactionsIcon },
+  { href: "/budgets", label: "Budgets", Icon: BudgetsIcon },
+  { href: "/pots", label: "Pots", Icon: PotsIcon },
+  { href: "/recurring-bills", label: "Bills", Icon: RecurringBillsIcon },
+];
+
+export function BottomNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Main navigation"
+      className="bg-grey-900 fixed right-0 bottom-0 left-0 z-50 flex rounded-t-2xl lg:hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      {navItems.map(({ href, label, Icon }) => {
+        const isActive = pathname === href;
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-label={label}
+            aria-current={isActive ? "page" : undefined}
+            className="flex flex-1 items-center justify-center py-400"
+          >
+            <span
+              className={cn(
+                "flex flex-col items-center gap-100 rounded-xl px-300 py-200 transition-colors duration-200",
+                isActive ? "bg-beige-100" : "",
+              )}
+            >
+              <Icon
+                className={cn(
+                  "transition-colors duration-200",
+                  isActive ? "text-green" : "text-grey-300",
+                )}
+              />
+              <span
+                className={cn(
+                  "text-preset-5 hidden sm:block",
+                  isActive ? "text-grey-900" : "text-grey-300",
+                )}
+              >
+                {label}
+              </span>
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/ui/BottomNav/index.ts
+++ b/src/components/ui/BottomNav/index.ts
@@ -1,0 +1,1 @@
+export { BottomNav } from "./BottomNav";

--- a/src/components/ui/Sidebar/Sidebar.tsx
+++ b/src/components/ui/Sidebar/Sidebar.tsx
@@ -68,6 +68,8 @@ export function Sidebar() {
             <Link
               key={href}
               href={href}
+              aria-label={label}
+              aria-current={isActive ? "page" : undefined}
               className={cn(
                 "group flex gap-400 rounded-r-xl border-l-4 px-400 py-400 pr-0 transition-colors duration-200",
                 isActive


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

Implements the bottom navigation bar for mobile and tablet (FIN-30).

- Mobile (< 640px) — icons only; active item has beige-100 background and green icon
- Tablet (640px–1024px) — icon + label below; same active state styling
- Desktop (lg+) — hidden via lg:hidden; navigation handled by the Sidebar
- Fixed at bottom — fixed bottom-0 with rounded-t-2xl
- iOS Safari — paddingBottom: env(safe-area-inset-bottom) prevents overlap with the home bar
- Accessibility — aria-current="page" on the active item, aria-label on all links and aria-label="Main navigation" on the nav element; same pattern applied to the Sidebar
- Content overlap — main gets pb-24 lg:pb-400 to prevent content from being hidden behind the bar on mobile/tablet

## 🔗 Related issue

Closes #22 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1.  Open on a mobile viewport (< 640px) — only icons should appear at the bottom; no labels visible
2.  Open on a tablet viewport (640px–1024px) — icon + label visible for each item
3.  Navigate between routes — only the current route item should have beige-100 background and green icon
4.  Open on desktop (>= 1024px) — bottom nav should not appear; lateral Sidebar should be visible
5.  On iOS Safari — the bar should not overlap the home indicator; page content should not be hidden behind the nav
6.  Inspect the DOM — active link must have aria-current="page", all links must have aria-label
7.  Run npm test — 10 tests in BottomNav.test.tsx and 7 in Sidebar.test.tsx should pass

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [x] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->

<img width="775" height="914" alt="Screenshot 2026-05-07 at 01 54 07" src="https://github.com/user-attachments/assets/a0301eae-517b-40ed-af0f-95a7a62fa7b1" />
<img width="775" height="914" alt="Screenshot 2026-05-07 at 01 54 00" src="https://github.com/user-attachments/assets/8ea1258a-7108-48af-a328-ed66fc2d90c2" />
