### PR TITLE
feat: FIN-17 — Componente Pagination

### DIFF
--- a/src/components/ui/Pagination/Pagination.stories.tsx
+++ b/src/components/ui/Pagination/Pagination.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Pagination } from "./Pagination";
+
+const meta: Meta<typeof Pagination> = {
+  title: "UI/Pagination",
+  component: Pagination,
+  tags: ["autodocs"],
+  argTypes: {
+    currentPage: { control: { type: "number", min: 1 } },
+    totalPages: { control: { type: "number", min: 0 } },
+    onPageChange: { action: "onPageChange" },
+  },
+  args: {
+    currentPage: 1,
+    totalPages: 5,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+export const Default: Story = {};
+
+export const MiddlePage: Story = {
+  args: { currentPage: 3, totalPages: 5 },
+};
+
+export const LastPage: Story = {
+  args: { currentPage: 5, totalPages: 5 },
+};
+
+export const ManyPages: Story = {
+  args: { currentPage: 5, totalPages: 20 },
+};
+
+export const SinglePage: Story = {
+  args: { currentPage: 1, totalPages: 1 },
+};
+
+export const Interactive: Story = {
+  args: { currentPage: 1, totalPages: 10 },
+  render: function Render(args) {
+    const [page, setPage] = useState(args.currentPage);
+    return <Pagination {...args} currentPage={page} onPageChange={setPage} />;
+  },
+};

--- a/src/components/ui/Pagination/Pagination.test.tsx
+++ b/src/components/ui/Pagination/Pagination.test.tsx
@@ -152,9 +152,8 @@ describe("Pagination", () => {
           onPageChange={onPageChange}
         />,
       );
-      await userEvent.click(
-        screen.getAllByRole("button", { name: "Go to page 4" })[0],
-      );
+      const [button] = screen.getAllByRole("button", { name: "Go to page 4" });
+      await userEvent.click(button!);
       expect(onPageChange).toHaveBeenCalledWith(4);
     });
 

--- a/src/components/ui/Pagination/Pagination.test.tsx
+++ b/src/components/ui/Pagination/Pagination.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Pagination } from "./Pagination";
+
+describe("Pagination", () => {
+  describe("rendering", () => {
+    it("renders nothing when totalPages is 1", () => {
+      const { container } = render(
+        <Pagination currentPage={1} totalPages={1} onPageChange={vi.fn()} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when totalPages is 0", () => {
+      const { container } = render(
+        <Pagination currentPage={1} totalPages={0} onPageChange={vi.fn()} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders prev and next buttons", () => {
+      render(
+        <Pagination currentPage={2} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      expect(
+        screen.getByRole("button", { name: /previous page/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /next page/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders page buttons for each page", () => {
+      render(
+        <Pagination currentPage={1} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      [1, 2, 3, 4, 5].forEach((page) => {
+        expect(
+          screen.getAllByRole("button", { name: `Go to page ${page}` }).length,
+        ).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it("renders with accessible nav label", () => {
+      render(
+        <Pagination currentPage={1} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      expect(
+        screen.getByRole("navigation", { name: /pagination/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("disabled state", () => {
+    it("disables prev button on first page", () => {
+      render(
+        <Pagination currentPage={1} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      expect(
+        screen.getByRole("button", { name: /previous page/i }),
+      ).toBeDisabled();
+    });
+
+    it("disables next button on last page", () => {
+      render(
+        <Pagination currentPage={5} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      expect(screen.getByRole("button", { name: /next page/i })).toBeDisabled();
+    });
+
+    it("enables prev button when not on first page", () => {
+      render(
+        <Pagination currentPage={3} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      expect(
+        screen.getByRole("button", { name: /previous page/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("enables next button when not on last page", () => {
+      render(
+        <Pagination currentPage={3} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      expect(
+        screen.getByRole("button", { name: /next page/i }),
+      ).not.toBeDisabled();
+    });
+  });
+
+  describe("active state", () => {
+    it("sets aria-current='page' on the current page button", () => {
+      render(
+        <Pagination currentPage={3} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      const activeButtons = screen.getAllByRole("button", {
+        name: "Go to page 3",
+      });
+      activeButtons.forEach((btn) =>
+        expect(btn).toHaveAttribute("aria-current", "page"),
+      );
+    });
+
+    it("does not set aria-current on inactive pages", () => {
+      render(
+        <Pagination currentPage={3} totalPages={5} onPageChange={vi.fn()} />,
+      );
+      const inactiveButtons = screen.getAllByRole("button", {
+        name: "Go to page 1",
+      });
+      inactiveButtons.forEach((btn) =>
+        expect(btn).not.toHaveAttribute("aria-current"),
+      );
+    });
+  });
+
+  describe("interactions", () => {
+    it("calls onPageChange with previous page when clicking prev", async () => {
+      const onPageChange = vi.fn();
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          onPageChange={onPageChange}
+        />,
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: /previous page/i }),
+      );
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it("calls onPageChange with next page when clicking next", async () => {
+      const onPageChange = vi.fn();
+      render(
+        <Pagination
+          currentPage={3}
+          totalPages={5}
+          onPageChange={onPageChange}
+        />,
+      );
+      await userEvent.click(screen.getByRole("button", { name: /next page/i }));
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+
+    it("calls onPageChange with the correct page number when clicking a page button", async () => {
+      const onPageChange = vi.fn();
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          onPageChange={onPageChange}
+        />,
+      );
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Go to page 4" })[0],
+      );
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+
+    it("does not call onPageChange when clicking disabled prev", async () => {
+      const onPageChange = vi.fn();
+      render(
+        <Pagination
+          currentPage={1}
+          totalPages={5}
+          onPageChange={onPageChange}
+        />,
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: /previous page/i }),
+      );
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it("does not call onPageChange when clicking disabled next", async () => {
+      const onPageChange = vi.fn();
+      render(
+        <Pagination
+          currentPage={5}
+          totalPages={5}
+          onPageChange={onPageChange}
+        />,
+      );
+      await userEvent.click(screen.getByRole("button", { name: /next page/i }));
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -1,0 +1,129 @@
+import { cn } from "@/lib/cn";
+import { ArrowRightIcon } from "../icons/ArrowRightIcon";
+
+type PageItem = number | "ellipsis";
+
+function getPageRange(
+  currentPage: number,
+  totalPages: number,
+  window: number,
+): PageItem[] {
+  if (totalPages <= window * 2 + 3) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const items: PageItem[] = [1];
+  const rangeStart = Math.max(2, currentPage - window);
+  const rangeEnd = Math.min(totalPages - 1, currentPage + window);
+
+  if (rangeStart > 2) items.push("ellipsis");
+  for (let i = rangeStart; i <= rangeEnd; i++) items.push(i);
+  if (rangeEnd < totalPages - 1) items.push("ellipsis");
+  items.push(totalPages);
+
+  return items;
+}
+
+const baseButton =
+  "flex items-center justify-center rounded-lg border text-preset-5-bold transition-colors duration-150 h-[40px] min-w-[40px] cursor-pointer disabled:cursor-not-allowed disabled:opacity-40";
+
+const inactiveButton =
+  "border-beige-500 bg-white text-grey-900 hover:bg-beige-100";
+
+const activeButton = "border-grey-900 bg-grey-900 text-white";
+
+type PaginationProps = {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const desktopPages = getPageRange(currentPage, totalPages, 2);
+  const mobilePages = getPageRange(currentPage, totalPages, 1);
+
+  const prevDisabled = currentPage === 1;
+  const nextDisabled = currentPage === totalPages;
+
+  return (
+    <nav aria-label="Pagination" className="flex items-center gap-200">
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={prevDisabled}
+        aria-label="Go to previous page"
+        className={cn(baseButton, inactiveButton, "gap-200 px-300")}
+      >
+        <ArrowRightIcon className="rotate-180" />
+        <span className="hidden sm:inline">Prev</span>
+      </button>
+
+      <div className="hidden items-center gap-200 sm:flex">
+        {desktopPages.map((page, i) =>
+          page === "ellipsis" ? (
+            <span
+              key={`ellipsis-desktop-${i}`}
+              className="text-preset-5-bold text-grey-500 flex h-[40px] min-w-[40px] items-center justify-center"
+            >
+              ...
+            </span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              aria-label={`Go to page ${page}`}
+              aria-current={page === currentPage ? "page" : undefined}
+              className={cn(
+                baseButton,
+                page === currentPage ? activeButton : inactiveButton,
+              )}
+            >
+              {page}
+            </button>
+          ),
+        )}
+      </div>
+
+      <div className="flex items-center gap-200 sm:hidden">
+        {mobilePages.map((page, i) =>
+          page === "ellipsis" ? (
+            <span
+              key={`ellipsis-mobile-${i}`}
+              className="text-preset-5-bold text-grey-500 flex h-[40px] min-w-[40px] items-center justify-center"
+            >
+              ...
+            </span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              aria-label={`Go to page ${page}`}
+              aria-current={page === currentPage ? "page" : undefined}
+              className={cn(
+                baseButton,
+                page === currentPage ? activeButton : inactiveButton,
+              )}
+            >
+              {page}
+            </button>
+          ),
+        )}
+      </div>
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={nextDisabled}
+        aria-label="Go to next page"
+        className={cn(baseButton, inactiveButton, "gap-200 px-300")}
+      >
+        <span className="hidden sm:inline">Next</span>
+        <ArrowRightIcon />
+      </button>
+    </nav>
+  );
+}

--- a/src/components/ui/Pagination/index.ts
+++ b/src/components/ui/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination } from "./Pagination";


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

Implements the Pagination component (FIN-17).

- Props — currentPage, totalPages, onPageChange
- Page numbers — windowed range with ellipsis; shows ±2 pages around current on desktop and ±1 on mobile
- Prev / Next buttons — show label + icon on desktop (sm+), icon only on mobile
- Disabled state — prev disabled on page 1, next disabled on last page
- Hidden on single page — returns null when totalPages <= 1
- Accessibility — aria-current="page" on the active page, aria-label on all navigation buttons, aria-label="Pagination" on the nav element

## 🔗 Related issue

Closes #25 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Run npm run storybook and open UI/Pagination
2. Use the Interactive story to navigate between pages — prev/next and page buttons should all update the current page correctly
3. On the first page, confirm the Prev button is disabled; on the last page, confirm Next is disabled
4. Set totalPages to 1 in the controls — the component should render nothing
5. Resize to mobile viewport — page labels on Prev/Next should disappear and the page number window should compact with ellipsis
6. Inspect the DOM — active page button must have aria-current="page", all buttons must have aria-label
7. Run npm test — 16 tests in Pagination.test.tsx should pass

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [x] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->

<img width="1231" height="536" alt="Screenshot 2026-05-07 at 02 17 06" src="https://github.com/user-attachments/assets/9892741d-a75d-4983-b4fe-a447f4679ef0" />
