### PR TITLE
feat: FIN-44 — Filtro por categoria

### DIFF
--- a/src/app/(dashboard)/transactions/_components/TransactionCategoryFilter.test.tsx
+++ b/src/app/(dashboard)/transactions/_components/TransactionCategoryFilter.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TransactionCategoryFilter } from "./TransactionCategoryFilter";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const mockPush = vi.fn();
+const mockUseRouter = vi.mocked(useRouter);
+const mockUseSearchParams = vi.mocked(useSearchParams);
+
+function makeSearchParams(init: Record<string, string> = {}) {
+  return new URLSearchParams(init) as unknown as ReturnType<
+    typeof useSearchParams
+  >;
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockUseRouter.mockReturnValue({ push: mockPush } as unknown as ReturnType<
+    typeof useRouter
+  >);
+  mockUseSearchParams.mockReturnValue(makeSearchParams());
+});
+
+describe("TransactionCategoryFilter", () => {
+  describe("rendering", () => {
+    it("renders a combobox", () => {
+      render(<TransactionCategoryFilter />);
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    it("shows 'All Transactions' as the default selected value", () => {
+      render(<TransactionCategoryFilter />);
+      expect(screen.getByRole("combobox")).toHaveTextContent(
+        "All Transactions",
+      );
+    });
+
+    it("shows the active category from the URL param", () => {
+      mockUseSearchParams.mockReturnValue(
+        makeSearchParams({ category: "Bills" }),
+      );
+      render(<TransactionCategoryFilter />);
+      expect(screen.getByRole("combobox")).toHaveTextContent("Bills");
+    });
+
+    it("shows 'Dining Out' label for DiningOut enum value", () => {
+      mockUseSearchParams.mockReturnValue(
+        makeSearchParams({ category: "DiningOut" }),
+      );
+      render(<TransactionCategoryFilter />);
+      expect(screen.getByRole("combobox")).toHaveTextContent("Dining Out");
+    });
+
+    it("shows all category options when opened", async () => {
+      render(<TransactionCategoryFilter />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "All Transactions" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Entertainment" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Bills" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Dining Out" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Personal Care" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "General" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("URL update", () => {
+    it("sets ?category=Bills&page=1 when a category is selected", async () => {
+      render(<TransactionCategoryFilter />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "Bills" }));
+      fireEvent.click(screen.getByRole("option", { name: "Bills" }));
+
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("category=Bills"),
+      );
+      expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("page=1"));
+    });
+
+    it("removes category param when 'All Transactions' is selected", async () => {
+      mockUseSearchParams.mockReturnValue(
+        makeSearchParams({ category: "Bills" }),
+      );
+      render(<TransactionCategoryFilter />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() =>
+        screen.getByRole("option", { name: "All Transactions" }),
+      );
+      fireEvent.click(screen.getByRole("option", { name: "All Transactions" }));
+
+      const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushedUrl).not.toContain("category=");
+    });
+
+    it("preserves search param when category changes", async () => {
+      mockUseSearchParams.mockReturnValue(makeSearchParams({ search: "Emma" }));
+      render(<TransactionCategoryFilter />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+      fireEvent.click(screen.getByRole("option", { name: "Groceries" }));
+
+      const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushedUrl).toContain("search=Emma");
+      expect(pushedUrl).toContain("category=Groceries");
+    });
+
+    it("resets page to 1 when category changes", async () => {
+      mockUseSearchParams.mockReturnValue(makeSearchParams({ page: "3" }));
+      render(<TransactionCategoryFilter />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "Shopping" }));
+      fireEvent.click(screen.getByRole("option", { name: "Shopping" }));
+
+      const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushedUrl).toContain("page=1");
+      expect(pushedUrl).not.toContain("page=3");
+    });
+  });
+});

--- a/src/app/(dashboard)/transactions/_components/TransactionCategoryFilter.tsx
+++ b/src/app/(dashboard)/transactions/_components/TransactionCategoryFilter.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Select } from "@/components/ui/Select";
+import { CATEGORY_LABELS } from "@/lib/categories";
+
+const ALL_VALUE = "all";
+
+const CATEGORY_OPTIONS = [
+  { value: ALL_VALUE, label: "All Transactions" },
+  ...Object.entries(CATEGORY_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  })),
+];
+
+export function TransactionCategoryFilter() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get("category") ?? ALL_VALUE;
+
+  function handleChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === ALL_VALUE) {
+      params.delete("category");
+    } else {
+      params.set("category", value);
+    }
+    params.set("page", "1");
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <Select
+      options={CATEGORY_OPTIONS}
+      value={current}
+      onValueChange={handleChange}
+    />
+  );
+}

--- a/src/app/(dashboard)/transactions/page.tsx
+++ b/src/app/(dashboard)/transactions/page.tsx
@@ -1,26 +1,36 @@
 import { auth } from "@/lib/auth/auth";
 import { prisma } from "@/lib/db/prisma";
+import { VALID_CATEGORIES } from "@/lib/categories";
 import { TransactionList } from "./_components/TransactionList";
 import { TransactionPagination } from "./_components/TransactionPagination";
 import { TransactionSearch } from "./_components/TransactionSearch";
+import { TransactionCategoryFilter } from "./_components/TransactionCategoryFilter";
 
 const PER_PAGE = 10;
 
 type Props = {
-  searchParams: Promise<{ page?: string; search?: string }>;
+  searchParams: Promise<{ page?: string; search?: string; category?: string }>;
 };
 
 export default async function TransactionsPage({ searchParams }: Props) {
-  const [session, { page, search }] = await Promise.all([auth(), searchParams]);
+  const [session, { page, search, category }] = await Promise.all([
+    auth(),
+    searchParams,
+  ]);
   const userId = session!.user!.id;
   const currentPage = Math.max(1, Number(page) || 1);
   const searchTerm = search?.trim() || undefined;
+  const categoryFilter =
+    category && VALID_CATEGORIES.includes(category as never)
+      ? (category as (typeof VALID_CATEGORIES)[number])
+      : undefined;
 
   const where = {
     userId,
     ...(searchTerm && {
       name: { contains: searchTerm, mode: "insensitive" as const },
     }),
+    ...(categoryFilter && { category: categoryFilter }),
   };
 
   const [transactions, total] = await Promise.all([
@@ -41,6 +51,14 @@ export default async function TransactionsPage({ searchParams }: Props) {
       <div className="rounded-2xl bg-white p-400 lg:p-800">
         <div className="mb-600 flex items-center gap-400">
           <TransactionSearch />
+          <div className="ml-auto flex items-center gap-300">
+            <span className="text-preset-4 text-grey-500 whitespace-nowrap">
+              Category
+            </span>
+            <div className="w-[177px]">
+              <TransactionCategoryFilter />
+            </div>
+          </div>
         </div>
         <TransactionList transactions={transactions} searchTerm={searchTerm} />
         {totalPages > 1 && (

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,0 +1,16 @@
+import type { Category } from "@/generated/prisma/enums";
+
+export const CATEGORY_LABELS: Record<Category, string> = {
+  Entertainment: "Entertainment",
+  Bills: "Bills",
+  Groceries: "Groceries",
+  DiningOut: "Dining Out",
+  Transportation: "Transportation",
+  PersonalCare: "Personal Care",
+  Education: "Education",
+  Lifestyle: "Lifestyle",
+  Shopping: "Shopping",
+  General: "General",
+};
+
+export const VALID_CATEGORIES = Object.keys(CATEGORY_LABELS) as Category[];


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

Adds a category filter to the transactions list. The selected category is persisted in the URL via` ?category=`, making the filtered view shareable and compatible with browser back/forward navigation. The filter combines correctly with the existing name search (`?search=`) and resets to page 1 on each change.

A shared`categories.ts` constant centralizes the enum key → display label mapping (e.g. **DiningOut** → "Dining Out"), used by both the filter component and server-side validation on the page.


## 🔗 Related issue

Closes #29 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Go to /transactions
2. Open the Category dropdown and select a category (e.g. "Bills") — the URL should update to ?category=Bills&page=1 and the list should show only that category
3. Select All Transactions — the category param should be removed from the URL and the full list restored
4. Apply a category filter, then type in the search input — confirm both ?category= and ?search= coexist and the list is filtered by both
5. Navigate to page 2, then change the category — confirm the URL resets to page=1
6. Navigate directly to ?category=DiningOut — confirm the dropdown shows "Dining Out" pre-selected

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)
<img width="1428" height="710" alt="Screenshot 2026-05-26 at 23 52 19" src="https://github.com/user-attachments/assets/9472d410-2402-46d3-8a79-6233794cef47" />
<img width="1428" height="710" alt="Screenshot 2026-05-26 at 23 52 11" src="https://github.com/user-attachments/assets/99c70d63-18c0-4637-bd85-70953d00c4b7" />


