### PR TITLE
feat: FIN-45 — Ordenação de transações

### DIFF
--- a/src/app/(dashboard)/transactions/_components/TransactionSearch.tsx
+++ b/src/app/(dashboard)/transactions/_components/TransactionSearch.tsx
@@ -44,6 +44,7 @@ export function TransactionSearch() {
       value={value}
       onChange={(e) => setValue(e.target.value)}
       icon={<SearchIcon className="h-4 w-4" />}
+      className="max-w-[320px]"
     />
   );
 }

--- a/src/app/(dashboard)/transactions/_components/TransactionSearch.tsx
+++ b/src/app/(dashboard)/transactions/_components/TransactionSearch.tsx
@@ -38,13 +38,14 @@ export function TransactionSearch() {
   }, [value]);
 
   return (
-    <Input
-      aria-label="Search transactions by name"
-      placeholder="Search transaction"
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      icon={<SearchIcon className="h-4 w-4" />}
-      className="max-w-[320px]"
-    />
+    <div className="w-full max-w-[320px]">
+      <Input
+        aria-label="Search transactions by name"
+        placeholder="Search transaction"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        icon={<SearchIcon className="h-4 w-4" />}
+      />
+    </div>
   );
 }

--- a/src/app/(dashboard)/transactions/_components/TransactionSort.test.tsx
+++ b/src/app/(dashboard)/transactions/_components/TransactionSort.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TransactionSort } from "./TransactionSort";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const mockPush = vi.fn();
+const mockUseRouter = vi.mocked(useRouter);
+const mockUseSearchParams = vi.mocked(useSearchParams);
+
+function makeSearchParams(init: Record<string, string> = {}) {
+  return new URLSearchParams(init) as unknown as ReturnType<
+    typeof useSearchParams
+  >;
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockUseRouter.mockReturnValue({ push: mockPush } as unknown as ReturnType<
+    typeof useRouter
+  >);
+  mockUseSearchParams.mockReturnValue(makeSearchParams());
+});
+
+describe("TransactionSort", () => {
+  describe("rendering", () => {
+    it("renders a combobox", () => {
+      render(<TransactionSort />);
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    it("shows 'Latest' as the default selected value", () => {
+      render(<TransactionSort />);
+      expect(screen.getByRole("combobox")).toHaveTextContent("Latest");
+    });
+
+    it("shows the active sort from the URL param", () => {
+      mockUseSearchParams.mockReturnValue(makeSearchParams({ sort: "oldest" }));
+      render(<TransactionSort />);
+      expect(screen.getByRole("combobox")).toHaveTextContent("Oldest");
+    });
+
+    it("shows all sort options when opened", async () => {
+      render(<TransactionSort />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "Latest" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Oldest" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "A to Z" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Z to A" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Highest" }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Lowest" }),
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("URL update", () => {
+    it("sets ?sort=oldest&page=1 when 'Oldest' is selected", async () => {
+      render(<TransactionSort />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "Oldest" }));
+      fireEvent.click(screen.getByRole("option", { name: "Oldest" }));
+
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("sort=oldest"),
+      );
+      expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("page=1"));
+    });
+
+    it("removes sort param when 'Latest' is selected (default)", async () => {
+      mockUseSearchParams.mockReturnValue(makeSearchParams({ sort: "oldest" }));
+      render(<TransactionSort />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "Latest" }));
+      fireEvent.click(screen.getByRole("option", { name: "Latest" }));
+
+      const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushedUrl).not.toContain("sort=");
+    });
+
+    it("preserves search and category params when sort changes", async () => {
+      mockUseSearchParams.mockReturnValue(
+        makeSearchParams({ search: "Emma", category: "Bills" }),
+      );
+      render(<TransactionSort />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "A to Z" }));
+      fireEvent.click(screen.getByRole("option", { name: "A to Z" }));
+
+      const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushedUrl).toContain("search=Emma");
+      expect(pushedUrl).toContain("category=Bills");
+      expect(pushedUrl).toContain("sort=az");
+    });
+
+    it("resets page to 1 when sort changes", async () => {
+      mockUseSearchParams.mockReturnValue(makeSearchParams({ page: "4" }));
+      render(<TransactionSort />);
+      fireEvent.click(screen.getByRole("combobox"));
+      await waitFor(() => screen.getByRole("option", { name: "Highest" }));
+      fireEvent.click(screen.getByRole("option", { name: "Highest" }));
+
+      const pushedUrl = mockPush.mock.calls[0]?.[0] as string;
+      expect(pushedUrl).toContain("page=1");
+      expect(pushedUrl).not.toContain("page=4");
+    });
+  });
+});

--- a/src/app/(dashboard)/transactions/_components/TransactionSort.tsx
+++ b/src/app/(dashboard)/transactions/_components/TransactionSort.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Select } from "@/components/ui/Select";
+
+export const SORT_OPTIONS = [
+  { value: "latest", label: "Latest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "az", label: "A to Z" },
+  { value: "za", label: "Z to A" },
+  { value: "highest", label: "Highest" },
+  { value: "lowest", label: "Lowest" },
+] as const;
+
+export type SortKey = (typeof SORT_OPTIONS)[number]["value"];
+
+export const DEFAULT_SORT: SortKey = "latest";
+
+export function TransactionSort() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = (searchParams.get("sort") as SortKey) ?? DEFAULT_SORT;
+
+  function handleChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === DEFAULT_SORT) {
+      params.delete("sort");
+    } else {
+      params.set("sort", value);
+    }
+    params.set("page", "1");
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <Select
+      options={[...SORT_OPTIONS]}
+      value={current}
+      onValueChange={handleChange}
+    />
+  );
+}

--- a/src/app/(dashboard)/transactions/page.tsx
+++ b/src/app/(dashboard)/transactions/page.tsx
@@ -5,15 +5,42 @@ import { TransactionList } from "./_components/TransactionList";
 import { TransactionPagination } from "./_components/TransactionPagination";
 import { TransactionSearch } from "./_components/TransactionSearch";
 import { TransactionCategoryFilter } from "./_components/TransactionCategoryFilter";
+import { TransactionSort, type SortKey } from "./_components/TransactionSort";
 
 const PER_PAGE = 10;
 
+const ORDER_BY: Record<
+  SortKey,
+  { date?: "asc" | "desc"; name?: "asc" | "desc"; amount?: "asc" | "desc" }
+> = {
+  latest: { date: "desc" },
+  oldest: { date: "asc" },
+  az: { name: "asc" },
+  za: { name: "desc" },
+  highest: { amount: "desc" },
+  lowest: { amount: "asc" },
+};
+
+const VALID_SORTS = new Set<SortKey>([
+  "latest",
+  "oldest",
+  "az",
+  "za",
+  "highest",
+  "lowest",
+]);
+
 type Props = {
-  searchParams: Promise<{ page?: string; search?: string; category?: string }>;
+  searchParams: Promise<{
+    page?: string;
+    search?: string;
+    category?: string;
+    sort?: string;
+  }>;
 };
 
 export default async function TransactionsPage({ searchParams }: Props) {
-  const [session, { page, search, category }] = await Promise.all([
+  const [session, { page, search, category, sort }] = await Promise.all([
     auth(),
     searchParams,
   ]);
@@ -24,6 +51,8 @@ export default async function TransactionsPage({ searchParams }: Props) {
     category && VALID_CATEGORIES.includes(category as never)
       ? (category as (typeof VALID_CATEGORIES)[number])
       : undefined;
+  const sortKey: SortKey =
+    sort && VALID_SORTS.has(sort as SortKey) ? (sort as SortKey) : "latest";
 
   const where = {
     userId,
@@ -36,7 +65,7 @@ export default async function TransactionsPage({ searchParams }: Props) {
   const [transactions, total] = await Promise.all([
     prisma.transaction.findMany({
       where,
-      orderBy: { date: "desc" },
+      orderBy: ORDER_BY[sortKey],
       skip: (currentPage - 1) * PER_PAGE,
       take: PER_PAGE,
     }),
@@ -52,6 +81,12 @@ export default async function TransactionsPage({ searchParams }: Props) {
         <div className="mb-600 flex items-center gap-400">
           <TransactionSearch />
           <div className="ml-auto flex items-center gap-300">
+            <span className="text-preset-4 text-grey-500 whitespace-nowrap">
+              Sort by
+            </span>
+            <div className="w-[114px]">
+              <TransactionSort />
+            </div>
             <span className="text-preset-4 text-grey-500 whitespace-nowrap">
               Category
             </span>


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
Adds sorting to the transactions list via a "Sort by" dropdown. The selected sort is persisted in the URL via `?sort=`, combining correctly with the existing `?search=` and `?category=` params. Selecting "Latest" (the default) removes the param to keep URLs clean.

Also fixes a bug from FIN-43 where the search icon was rendered outside the input boundary when `max-w-[320px]` was applied — the constraint was on the `<input>` element itself instead of the wrapper div that contains the absolute-positioned icon.

## 🔗 Related issue

Closes #30 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1.
2.
3.

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1428" height="592" alt="Screenshot 2026-05-27 at 00 09 06" src="https://github.com/user-attachments/assets/9a751c68-a3c3-4ff8-94e7-2cb1e3bdef1c" />
<img width="1428" height="446" alt="Screenshot 2026-05-27 at 00 08 52" src="https://github.com/user-attachments/assets/f33e3f4c-560a-4446-aa82-3abe4071939d" />
<img width="1428" height="446" alt="Screenshot 2026-05-27 at 00 08 41" src="https://github.com/user-attachments/assets/2e137541-77a3-4818-8e2b-05320edfd1e2" />

