### PR TITLE
feat: FIN-48 — Server action createTransaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "postinstall": "prisma generate",
     "prepare": "husky",
     "db:seed": "tsx prisma/seed.ts"
   },

--- a/src/server/actions/transactions.test.ts
+++ b/src/server/actions/transactions.test.ts
@@ -26,7 +26,7 @@ const VALID_INPUT = {
 function authenticated(userId = "user-1") {
   mockAuth.mockResolvedValue({
     user: { id: userId },
-  } as Awaited<ReturnType<typeof auth>>);
+  } as unknown as Awaited<ReturnType<typeof auth>>);
 }
 
 beforeEach(() => {
@@ -37,7 +37,9 @@ beforeEach(() => {
 describe("createTransaction", () => {
   describe("authentication", () => {
     it("throws when the user is not authenticated", async () => {
-      mockAuth.mockResolvedValue(null);
+      mockAuth.mockResolvedValue(
+        null as unknown as Awaited<ReturnType<typeof auth>>,
+      );
 
       await expect(createTransaction(VALID_INPUT)).rejects.toThrow(
         "Unauthorized",
@@ -45,7 +47,7 @@ describe("createTransaction", () => {
     });
 
     it("throws when session has no user id", async () => {
-      mockAuth.mockResolvedValue({ user: {} } as Awaited<
+      mockAuth.mockResolvedValue({ user: {} } as unknown as Awaited<
         ReturnType<typeof auth>
       >);
 

--- a/src/server/actions/transactions.test.ts
+++ b/src/server/actions/transactions.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTransaction } from "./transactions";
+
+vi.mock("@/lib/auth/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { transaction: { create: vi.fn() } },
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { auth } from "@/lib/auth/auth";
+import { prisma } from "@/lib/db/prisma";
+import { revalidatePath } from "next/cache";
+
+const mockAuth = vi.mocked(auth);
+const mockCreate = vi.mocked(prisma.transaction.create);
+const mockRevalidatePath = vi.mocked(revalidatePath);
+
+const VALID_INPUT = {
+  name: "Coffee Shop",
+  amount: -5.5,
+  category: "General" as const,
+  date: new Date("2024-08-19"),
+  recurring: false,
+};
+
+function authenticated(userId = "user-1") {
+  mockAuth.mockResolvedValue({
+    user: { id: userId },
+  } as Awaited<ReturnType<typeof auth>>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockResolvedValue({} as never);
+});
+
+describe("createTransaction", () => {
+  describe("authentication", () => {
+    it("throws when the user is not authenticated", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      await expect(createTransaction(VALID_INPUT)).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+
+    it("throws when session has no user id", async () => {
+      mockAuth.mockResolvedValue({ user: {} } as Awaited<
+        ReturnType<typeof auth>
+      >);
+
+      await expect(createTransaction(VALID_INPUT)).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+  });
+
+  describe("validation — name", () => {
+    it("returns error when name is empty", async () => {
+      authenticated();
+      const result = await createTransaction({ ...VALID_INPUT, name: "" });
+
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { name: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+  });
+
+  describe("validation — amount", () => {
+    it("returns error when amount is zero", async () => {
+      authenticated();
+      const result = await createTransaction({ ...VALID_INPUT, amount: 0 });
+
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: {
+          amount: expect.arrayContaining(["Amount cannot be zero"]),
+        },
+      });
+    });
+
+    it("accepts negative amounts (expenses)", async () => {
+      authenticated();
+      const result = await createTransaction({ ...VALID_INPUT, amount: -55.5 });
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it("accepts positive amounts (income)", async () => {
+      authenticated();
+      const result = await createTransaction({
+        ...VALID_INPUT,
+        amount: 120.0,
+      });
+
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe("validation — date", () => {
+    it("returns error when date is in the future", async () => {
+      authenticated();
+      const future = new Date();
+      future.setDate(future.getDate() + 1);
+
+      const result = await createTransaction({
+        ...VALID_INPUT,
+        date: future,
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: {
+          date: expect.arrayContaining(["Date cannot be in the future"]),
+        },
+      });
+    });
+
+    it("accepts today's date", async () => {
+      authenticated();
+      const result = await createTransaction({
+        ...VALID_INPUT,
+        date: new Date(),
+      });
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it("accepts a past date", async () => {
+      authenticated();
+      const result = await createTransaction({
+        ...VALID_INPUT,
+        date: new Date("2024-01-01"),
+      });
+
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe("validation — category", () => {
+    it("returns error when category is invalid", async () => {
+      authenticated();
+      const result = await createTransaction({
+        ...VALID_INPUT,
+        category: "InvalidCategory" as never,
+      });
+
+      expect(result).toMatchObject({ success: false });
+    });
+
+    it("accepts all valid categories", async () => {
+      authenticated();
+      const categories = [
+        "Entertainment",
+        "Bills",
+        "Groceries",
+        "DiningOut",
+        "Transportation",
+        "PersonalCare",
+        "Education",
+        "Lifestyle",
+        "Shopping",
+        "General",
+      ] as const;
+
+      for (const category of categories) {
+        const result = await createTransaction({ ...VALID_INPUT, category });
+        expect(result).toEqual({ success: true });
+      }
+    });
+  });
+
+  describe("success", () => {
+    it("creates the transaction with the correct data", async () => {
+      authenticated("user-42");
+      await createTransaction(VALID_INPUT);
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: {
+          name: "Coffee Shop",
+          amount: -5.5,
+          category: "General",
+          date: VALID_INPUT.date,
+          recurring: false,
+          avatar: "",
+          userId: "user-42",
+        },
+      });
+    });
+
+    it("revalidates the transactions path", async () => {
+      authenticated();
+      await createTransaction(VALID_INPUT);
+
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/transactions");
+    });
+
+    it("returns { success: true }", async () => {
+      authenticated();
+      const result = await createTransaction(VALID_INPUT);
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it("does not call prisma when validation fails", async () => {
+      authenticated();
+      await createTransaction({ ...VALID_INPUT, amount: 0 });
+
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("does not revalidate when validation fails", async () => {
+      authenticated();
+      await createTransaction({ ...VALID_INPUT, name: "" });
+
+      expect(mockRevalidatePath).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/actions/transactions.ts
+++ b/src/server/actions/transactions.ts
@@ -1,0 +1,64 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { auth } from "@/lib/auth/auth";
+import { prisma } from "@/lib/db/prisma";
+import { Category } from "@/generated/prisma/enums";
+
+const createTransactionSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  amount: z
+    .number()
+    .refine((v) => v !== 0, { message: "Amount cannot be zero" }),
+  category: z.enum(Category),
+  date: z.coerce.date().refine((d) => d <= new Date(), {
+    message: "Date cannot be in the future",
+  }),
+  recurring: z.boolean(),
+});
+
+export type CreateTransactionInput = z.infer<typeof createTransactionSchema>;
+
+export type CreateTransactionResult =
+  | { success: true }
+  | {
+      success: false;
+      fieldErrors: Partial<Record<keyof CreateTransactionInput, string[]>>;
+    };
+
+export async function createTransaction(
+  input: CreateTransactionInput,
+): Promise<CreateTransactionResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const parsed = createTransactionSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      fieldErrors: z.flattenError(parsed.error).fieldErrors as Partial<
+        Record<keyof CreateTransactionInput, string[]>
+      >,
+    };
+  }
+
+  const { name, amount, category, date, recurring } = parsed.data;
+
+  await prisma.transaction.create({
+    data: {
+      name,
+      amount,
+      category,
+      date,
+      recurring,
+      avatar: "",
+      userId: session.user.id,
+    },
+  });
+
+  revalidatePath("/transactions");
+  return { success: true };
+}


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

Implements the `createTransaction` server action with Zod validation, authentication guard, and Prisma persistence.

- Validates name (non-empty), amount (non-zero), category (enum), date (not in the future), and recurring flag
- Throws `Unauthorized` when the session is missing or has no user id
- Returns `{ success: true }` on success or `{ success: false, fieldErrors }` on validation failure
- Revalidates `/transactions` after a successful write

## 🔗 Related issue

Closes #90 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1.
2.
3.

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
