### PR TITLE
feat:  FIN-50 - Schema Prisma para Budget

### DIFF
--- a/prisma/migrations/20260527043632_fin_50_budget_schema/migration.sql
+++ b/prisma/migrations/20260527043632_fin_50_budget_schema/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "Theme" AS ENUM ('Green', 'Yellow', 'Cyan', 'Navy', 'Red', 'Purple', 'Turquoise', 'Brown', 'Magenta', 'Blue', 'navy-grey', 'army-green', 'Gold', 'Orange');
+
+-- CreateTable
+CREATE TABLE "Budget" (
+    "id" TEXT NOT NULL,
+    "category" "Category" NOT NULL,
+    "maximum" DOUBLE PRECISION NOT NULL,
+    "theme" "Theme" NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Budget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Budget_userId_category_key" ON "Budget"("userId", "category");
+
+-- AddForeignKey
+ALTER TABLE "Budget" ADD CONSTRAINT "Budget_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260527043754_fin_50_add_pink_theme/migration.sql
+++ b/prisma/migrations/20260527043754_fin_50_add_pink_theme/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Theme" ADD VALUE 'Pink';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,24 @@ datasource db {
   provider = "postgresql"
 }
 
+enum Theme {
+  Green
+  Yellow
+  Cyan
+  Navy
+  Red
+  Purple
+  Turquoise
+  Brown
+  Magenta
+  Blue
+  NavyGrey  @map("navy-grey")
+  ArmyGreen @map("army-green")
+  Pink
+  Gold
+  Orange
+}
+
 enum Category {
   Entertainment
   Bills
@@ -37,9 +55,25 @@ model User {
   accounts     Account[]
   sessions     Session[]
   transactions Transaction[]
+  budgets      Budget[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Budget {
+  id       String   @id @default(cuid())
+  category Category
+  maximum  Float
+  theme    Theme
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, category])
 }
 
 model Transaction {


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

Adds the Budget model and Theme enum to the Prisma schema, with the corresponding database migrations.

- Theme enum with all 15 colors from Figma: Green, Yellow, Cyan, Navy, Red, Purple, Turquoise, Brown, Magenta, Blue, NavyGrey, ArmyGreen, Pink, Gold, Orange
- Budget model with fields: id, category (Category enum), maximum (Float), theme (Theme enum), userId, timestamps
- Relation with User (cascade delete)
- @@unique([userId, category]) prevents two budgets with the same category per user
- Two migrations: initial Budget schema + Pink color added after Figma review

## 🔗 Related issue

Closes #36 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Run npx prisma migrate deploy (or confirm migrations already applied)
2. Run npm run build — should pass with no errors
3. Confirm in the database that the Budget table exists with the Theme and Category enum constraints
4. Try inserting two budgets with the same category for the same user — should fail with a unique constraint error

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [ ] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
