### PR TITLE
feat: FIN-51 - Listagem de budgets & FIN-53 - Modal Add new budget

### DIFF
--- a/src/app/(dashboard)/budgets/_components/AddBudgetModal.tsx
+++ b/src/app/(dashboard)/budgets/_components/AddBudgetModal.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 import { CATEGORY_LABELS } from "@/lib/categories";
 import { THEME_COLORS, THEME_LABELS } from "@/lib/themes";
-import type { Theme } from "@/generated/prisma/enums";
+import type { Category, Theme } from "@/generated/prisma/enums";
 import { createBudget } from "@/server/actions/budgets";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState, useTransition } from "react";
@@ -26,18 +26,23 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>;
 
-const CATEGORY_OPTIONS = Object.entries(CATEGORY_LABELS).map(
-  ([value, label]) => ({ value, label }),
-);
-
 type Props = {
   usedThemes: Theme[];
+  usedCategories: Category[];
 };
 
-export function AddBudgetModal({ usedThemes }: Props) {
+export function AddBudgetModal({ usedThemes, usedCategories }: Props) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
+
+  const categoryOptions = Object.entries(CATEGORY_LABELS).map(
+    ([value, label]) => ({
+      value,
+      label,
+      alreadyUsed: usedCategories.includes(value as Category),
+    }),
+  );
 
   const themeOptions = Object.entries(THEME_LABELS).map(([value, label]) => ({
     value,
@@ -123,7 +128,7 @@ export function AddBudgetModal({ usedThemes }: Props) {
             <Select
               label="Budget Category"
               placeholder="Select a category"
-              options={CATEGORY_OPTIONS}
+              options={categoryOptions}
               value={field.value}
               onValueChange={field.onChange}
               error={errors.category?.message}

--- a/src/app/(dashboard)/budgets/_components/AddBudgetModal.tsx
+++ b/src/app/(dashboard)/budgets/_components/AddBudgetModal.tsx
@@ -7,18 +7,20 @@ import { Select } from "@/components/ui/Select";
 import { CATEGORY_LABELS } from "@/lib/categories";
 import { THEME_COLORS, THEME_LABELS } from "@/lib/themes";
 import type { Theme } from "@/generated/prisma/enums";
+import { createBudget } from "@/server/actions/budgets";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
 const formSchema = z.object({
+  category: z.string().min(1, "Select a category"),
   maximum: z
     .string()
-    .min(1, "Amount is required")
+    .min(1, "Maximum is required")
     .refine((v) => !isNaN(Number(v)), "Must be a valid number")
-    .refine((v) => Number(v) !== 0, "Amount cannot be zero"),
-  category: z.string().min(1, "Select a category"),
+    .refine((v) => Number(v) > 0, "Maximum must be greater than zero"),
   theme: z.string().min(1, "Select a theme"),
 });
 
@@ -33,7 +35,9 @@ type Props = {
 };
 
 export function AddBudgetModal({ usedThemes }: Props) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
   const themeOptions = Object.entries(THEME_LABELS).map(([value, label]) => ({
     value,
@@ -63,6 +67,32 @@ export function AddBudgetModal({ usedThemes }: Props) {
     setOpen(next);
   }
 
+  function onSubmit(data: FormValues) {
+    startTransition(async () => {
+      const result = await createBudget({
+        category: data.category as Parameters<
+          typeof createBudget
+        >[0]["category"],
+        maximum: Number(data.maximum),
+        theme: data.theme as Parameters<typeof createBudget>[0]["theme"],
+      });
+
+      if (result.success) {
+        handleOpenChange(false);
+        router.refresh();
+        return;
+      }
+
+      for (const [field, messages] of Object.entries(
+        result.fieldErrors ?? {},
+      )) {
+        if (messages?.length) {
+          setError(field as keyof FormValues, { message: messages[0] });
+        }
+      }
+    });
+  }
+
   return (
     <Dialog
       open={open}
@@ -75,13 +105,14 @@ export function AddBudgetModal({ usedThemes }: Props) {
       title="Add New Budget"
       description="Choose a category to set a spending budget. These categories can help you monitor spending."
       footer={
-        <Button type="submit" form="add-budget-form">
+        <Button type="submit" form="add-budget-form" loading={isPending}>
           Add Budget
         </Button>
       }
     >
       <form
         id="add-budget-form"
+        onSubmit={handleSubmit(onSubmit)}
         className="flex flex-col gap-400 pb-100"
         noValidate
       >

--- a/src/app/(dashboard)/budgets/_components/AddBudgetModal.tsx
+++ b/src/app/(dashboard)/budgets/_components/AddBudgetModal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { CATEGORY_LABELS } from "@/lib/categories";
+import { THEME_COLORS, THEME_LABELS } from "@/lib/themes";
+import type { Theme } from "@/generated/prisma/enums";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+  maximum: z
+    .string()
+    .min(1, "Amount is required")
+    .refine((v) => !isNaN(Number(v)), "Must be a valid number")
+    .refine((v) => Number(v) !== 0, "Amount cannot be zero"),
+  category: z.string().min(1, "Select a category"),
+  theme: z.string().min(1, "Select a theme"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+const CATEGORY_OPTIONS = Object.entries(CATEGORY_LABELS).map(
+  ([value, label]) => ({ value, label }),
+);
+
+type Props = {
+  usedThemes: Theme[];
+};
+
+export function AddBudgetModal({ usedThemes }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const themeOptions = Object.entries(THEME_LABELS).map(([value, label]) => ({
+    value,
+    label,
+    color: THEME_COLORS[value as Theme],
+    alreadyUsed: usedThemes.includes(value as Theme),
+  }));
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      maximum: "",
+      category: "",
+      theme: "",
+    },
+  });
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    setOpen(next);
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      trigger={
+        <Button size="sm" className="w-auto whitespace-nowrap">
+          + Add New Budget
+        </Button>
+      }
+      title="Add New Budget"
+      description="Choose a category to set a spending budget. These categories can help you monitor spending."
+      footer={
+        <Button type="submit" form="add-budget-form">
+          Add Budget
+        </Button>
+      }
+    >
+      <form
+        id="add-budget-form"
+        className="flex flex-col gap-400 pb-100"
+        noValidate
+      >
+        <Controller
+          control={control}
+          name="category"
+          render={({ field }) => (
+            <Select
+              label="Budget Category"
+              placeholder="Select a category"
+              options={CATEGORY_OPTIONS}
+              value={field.value}
+              onValueChange={field.onChange}
+              error={errors.category?.message}
+            />
+          )}
+        />
+
+        <Input
+          label="Maximum Spend"
+          type="number"
+          step="0.01"
+          placeholder="e.g. 2000"
+          prefix="$"
+          error={errors.maximum?.message}
+          {...register("maximum")}
+        />
+
+        <Controller
+          control={control}
+          name="theme"
+          render={({ field }) => (
+            <Select
+              label="Theme"
+              placeholder="Select a theme"
+              options={themeOptions}
+              value={field.value}
+              onValueChange={field.onChange}
+              error={errors.theme?.message}
+              avoidCollisions={false}
+            />
+          )}
+        />
+      </form>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
@@ -81,22 +81,20 @@ export function BudgetCard({ budget, spent, latestTransactions }: Props) {
           <p className="text-preset-4-bold text-grey-900">Latest Spending</p>
           <Link
             href={`/transactions?category=${category}`}
-            className="text-preset-4 text-grey-500 hover:text-grey-900 flex items-center gap-150 transition-colors"
+            className="text-preset-4 text-grey-500 hover:text-grey-900 flex items-center gap-400 transition-colors"
           >
             See All
             <svg
-              width="6"
-              height="10"
-              viewBox="0 0 6 10"
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
               fill="none"
+              xmlns="http://www.w3.org/2000/svg"
               aria-hidden="true"
             >
               <path
-                d="M1 1l4 4-4 4"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+                d="M4.76531 1.98468L8.51531 5.73468C8.55018 5.76951 8.57784 5.81087 8.59671 5.85639C8.61558 5.90192 8.6253 5.95071 8.6253 5.99999C8.6253 6.04928 8.61558 6.09807 8.59671 6.1436C8.57784 6.18912 8.55018 6.23048 8.51531 6.26531L4.76531 10.0153C4.71287 10.0678 4.64602 10.1036 4.57324 10.1181C4.50046 10.1326 4.42501 10.1251 4.35645 10.0967C4.2879 10.0683 4.22931 10.0202 4.18811 9.95849C4.1469 9.89677 4.12494 9.82421 4.125 9.75L4.125 2.24999C4.12494 2.17578 4.1469 2.10322 4.18811 2.0415C4.22931 1.97978 4.2879 1.93167 4.35645 1.90326C4.42501 1.87485 4.50046 1.86743 4.57324 1.88192C4.64602 1.89642 4.71287 1.93218 4.76531 1.98468Z"
+                fill="currentColor"
               />
             </svg>
           </Link>

--- a/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link";
+import type { BudgetModel as Budget } from "@/generated/prisma/models";
+import type { Category } from "@/generated/prisma/enums";
+import { CATEGORY_LABELS } from "@/lib/categories";
+import { THEME_COLORS } from "@/lib/themes";
+import { formatCurrency, formatDate, getInitials } from "@/lib/format";
+
+type Transaction = {
+  id: string;
+  name: string;
+  amount: number;
+  date: Date;
+  avatar: string;
+};
+
+type Props = {
+  budget: Budget;
+  spent: number;
+  latestTransactions: Transaction[];
+};
+
+const fmt = (amount: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
+    amount,
+  );
+
+export function BudgetCard({ budget, spent, latestTransactions }: Props) {
+  const { category, maximum, theme } = budget;
+  const themeColor = THEME_COLORS[theme];
+  const remaining = Math.max(0, maximum - spent);
+  const progress = Math.min(100, (spent / maximum) * 100);
+  const categoryLabel = CATEGORY_LABELS[category as Category];
+
+  return (
+    <div className="rounded-2xl bg-white p-500">
+      {/* Header */}
+      <div className="mb-500 flex items-center justify-between">
+        <div className="flex items-center gap-200">
+          <span
+            className="h-[16px] w-[16px] shrink-0 rounded-full"
+            style={{ backgroundColor: themeColor }}
+            aria-hidden="true"
+          />
+          <h2 className="text-preset-2 text-grey-900">{categoryLabel}</h2>
+        </div>
+      </div>
+
+      {/* Maximum */}
+      <p className="text-preset-4 text-grey-500 mb-300">
+        Maximum of {fmt(maximum)}
+      </p>
+
+      {/* Progress bar */}
+      <div className="bg-beige-100 mb-400 h-[12px] w-full overflow-hidden rounded-full">
+        <div
+          className="h-full rounded-full transition-all duration-300"
+          style={{ backgroundColor: themeColor, width: `${progress}%` }}
+          role="progressbar"
+          aria-valuenow={Math.round(progress)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${Math.round(progress)}% of budget spent`}
+        />
+      </div>
+
+      {/* Spent / Remaining */}
+      <div className="mb-500 grid grid-cols-2 gap-400">
+        <div className="border-l-4 pl-300" style={{ borderColor: themeColor }}>
+          <p className="text-preset-5 text-grey-500 mb-100">Spent</p>
+          <p className="text-preset-4-bold text-grey-900">{fmt(spent)}</p>
+        </div>
+        <div className="border-beige-500 border-l-4 pl-300">
+          <p className="text-preset-5 text-grey-500 mb-100">Remaining</p>
+          <p className="text-preset-4-bold text-grey-900">{fmt(remaining)}</p>
+        </div>
+      </div>
+
+      {/* Latest Spending */}
+      <div className="bg-beige-100 rounded-xl p-400">
+        <div className="mb-300 flex items-center justify-between">
+          <p className="text-preset-4-bold text-grey-900">Latest Spending</p>
+          <Link
+            href={`/transactions?category=${category}`}
+            className="text-preset-4 text-grey-500 hover:text-grey-900 flex items-center gap-150 transition-colors"
+          >
+            See All
+            <svg
+              width="6"
+              height="10"
+              viewBox="0 0 6 10"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M1 1l4 4-4 4"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+        </div>
+
+        {latestTransactions.length === 0 ? (
+          <p className="text-preset-5 text-grey-500 py-200">
+            No transactions yet
+          </p>
+        ) : (
+          <ul>
+            {latestTransactions.map((t, i) => (
+              <li
+                key={t.id}
+                className={`flex items-center justify-between py-300 ${
+                  i < latestTransactions.length - 1
+                    ? "border-grey-100 border-b"
+                    : ""
+                }`}
+              >
+                <div className="flex items-center gap-300">
+                  <div className="bg-grey-100 flex h-800 w-800 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                    {t.avatar ? (
+                      <img
+                        src={t.avatar}
+                        alt={t.name}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <span className="text-preset-5-bold text-grey-500">
+                        {getInitials(t.name)}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-preset-5-bold text-grey-900">{t.name}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-preset-5-bold text-grey-900">
+                    {formatCurrency(t.amount)}
+                  </p>
+                  <p className="text-preset-5 text-grey-500">
+                    {formatDate(t.date)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/budgets/_components/BudgetList.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetList.tsx
@@ -1,0 +1,38 @@
+import type { BudgetModel as Budget } from "@/generated/prisma/models";
+import type { Category } from "@/generated/prisma/enums";
+import { BudgetCard } from "./BudgetCard";
+
+type Transaction = {
+  id: string;
+  name: string;
+  amount: number;
+  date: Date;
+  avatar: string;
+};
+
+type Props = {
+  budgets: Budget[];
+  spentByCategory: Record<Category, number>;
+  latestByCategory: Record<Category, Transaction[]>;
+};
+
+export function BudgetList({
+  budgets,
+  spentByCategory,
+  latestByCategory,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-300">
+      {budgets.map((budget) => (
+        <BudgetCard
+          key={budget.id}
+          budget={budget}
+          spent={spentByCategory[budget.category as Category] ?? 0}
+          latestTransactions={
+            latestByCategory[budget.category as Category] ?? []
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/budgets/_components/BudgetListSkeleton.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetListSkeleton.tsx
@@ -1,0 +1,65 @@
+function SkeletonTransaction() {
+  return (
+    <div className="border-grey-100 flex items-center justify-between border-b py-300 last:border-none">
+      <div className="flex items-center gap-300">
+        <div className="bg-grey-100 h-800 w-800 shrink-0 animate-pulse rounded-full" />
+        <div className="bg-grey-100 h-[14px] w-[100px] animate-pulse rounded" />
+      </div>
+      <div className="flex flex-col items-end gap-100">
+        <div className="bg-grey-100 h-[14px] w-[50px] animate-pulse rounded" />
+        <div className="bg-grey-100 h-[12px] w-[70px] animate-pulse rounded" />
+      </div>
+    </div>
+  );
+}
+
+function BudgetCardSkeleton() {
+  return (
+    <div className="rounded-2xl bg-white p-500">
+      {/* Header */}
+      <div className="mb-500 flex items-center gap-200">
+        <div className="bg-grey-100 h-[16px] w-[16px] shrink-0 animate-pulse rounded-full" />
+        <div className="bg-grey-100 h-[20px] w-[120px] animate-pulse rounded" />
+      </div>
+
+      {/* Maximum */}
+      <div className="bg-grey-100 mb-300 h-[14px] w-[140px] animate-pulse rounded" />
+
+      {/* Progress bar */}
+      <div className="bg-beige-100 mb-400 h-[12px] w-full animate-pulse rounded-full" />
+
+      {/* Spent / Remaining */}
+      <div className="mb-500 grid grid-cols-2 gap-400">
+        <div className="border-grey-100 border-l-4 pl-300">
+          <div className="bg-grey-100 mb-100 h-[12px] w-[40px] animate-pulse rounded" />
+          <div className="bg-grey-100 h-[16px] w-[60px] animate-pulse rounded" />
+        </div>
+        <div className="border-grey-100 border-l-4 pl-300">
+          <div className="bg-grey-100 mb-100 h-[12px] w-[60px] animate-pulse rounded" />
+          <div className="bg-grey-100 h-[16px] w-[60px] animate-pulse rounded" />
+        </div>
+      </div>
+
+      {/* Latest Spending */}
+      <div className="bg-beige-100 rounded-xl p-400">
+        <div className="mb-300 flex items-center justify-between">
+          <div className="bg-grey-100 h-[16px] w-[120px] animate-pulse rounded" />
+          <div className="bg-grey-100 h-[14px] w-[50px] animate-pulse rounded" />
+        </div>
+        <SkeletonTransaction />
+        <SkeletonTransaction />
+        <SkeletonTransaction />
+      </div>
+    </div>
+  );
+}
+
+export function BudgetListSkeleton() {
+  return (
+    <div className="flex flex-col gap-300">
+      <BudgetCardSkeleton />
+      <BudgetCardSkeleton />
+      <BudgetCardSkeleton />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/budgets/loading.tsx
+++ b/src/app/(dashboard)/budgets/loading.tsx
@@ -1,0 +1,13 @@
+import { BudgetListSkeleton } from "./_components/BudgetListSkeleton";
+
+export default function BudgetsLoading() {
+  return (
+    <div className="p-400 lg:p-1000">
+      <div className="mb-800 flex items-center justify-between">
+        <h1 className="text-preset-1 text-grey-900">Budgets</h1>
+        <div className="bg-grey-900 h-[40px] w-[140px] animate-pulse rounded-lg" />
+      </div>
+      <BudgetListSkeleton />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -8,16 +8,20 @@ export default async function BudgetsPage() {
 
   const budgets = await prisma.budget.findMany({
     where: { userId },
-    select: { theme: true },
+    select: { theme: true, category: true },
   });
 
   const usedThemes = budgets.map((b) => b.theme);
+  const usedCategories = budgets.map((b) => b.category);
 
   return (
     <div className="p-400 lg:p-1000">
       <div className="mb-800 flex items-center justify-between">
         <h1 className="text-preset-1 text-grey-900">Budgets</h1>
-        <AddBudgetModal usedThemes={usedThemes} />
+        <AddBudgetModal
+          usedThemes={usedThemes}
+          usedCategories={usedCategories}
+        />
       </div>
       {budgets.length === 0 && (
         <div className="flex flex-col items-center justify-center gap-400 rounded-2xl bg-white px-400 py-[80px] text-center">
@@ -37,7 +41,8 @@ export default async function BudgetsPage() {
           <div className="flex flex-col gap-100">
             <p className="text-preset-2 text-grey-900">No budgets yet</p>
             <p className="text-preset-4 text-grey-500 max-w-[320px]">
-              Create your first budget to start tracking your spending by category.
+              Create your first budget to start tracking your spending by
+              category.
             </p>
           </div>
         </div>

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -1,0 +1,9 @@
+export default function BudgetsPage() {
+  return (
+    <div className="p-400 lg:p-1000">
+      <div className="mb-800 flex items-center justify-between">
+        <h1 className="text-preset-1 text-grey-900">Budgets</h1>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -1,8 +1,23 @@
-export default function BudgetsPage() {
+import { auth } from "@/lib/auth/auth";
+import { prisma } from "@/lib/db/prisma";
+import { AddBudgetModal } from "./_components/AddBudgetModal";
+
+export default async function BudgetsPage() {
+  const session = await auth();
+  const userId = session!.user!.id!;
+
+  const budgets = await prisma.budget.findMany({
+    where: { userId },
+    select: { theme: true },
+  });
+
+  const usedThemes = budgets.map((b) => b.theme);
+
   return (
     <div className="p-400 lg:p-1000">
       <div className="mb-800 flex items-center justify-between">
         <h1 className="text-preset-1 text-grey-900">Budgets</h1>
+        <AddBudgetModal usedThemes={usedThemes} />
       </div>
     </div>
   );

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -1,6 +1,8 @@
 import { auth } from "@/lib/auth/auth";
 import { prisma } from "@/lib/db/prisma";
+import type { Category } from "@/generated/prisma/enums";
 import { AddBudgetModal } from "./_components/AddBudgetModal";
+import { BudgetList } from "./_components/BudgetList";
 
 export default async function BudgetsPage() {
   const session = await auth();
@@ -8,11 +10,59 @@ export default async function BudgetsPage() {
 
   const budgets = await prisma.budget.findMany({
     where: { userId },
-    select: { theme: true, category: true },
+    orderBy: { createdAt: "asc" },
   });
 
   const usedThemes = budgets.map((b) => b.theme);
   const usedCategories = budgets.map((b) => b.category);
+
+  const now = new Date();
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+  const [monthTransactions, allCategoryTransactions] = await Promise.all([
+    prisma.transaction.findMany({
+      where: {
+        userId,
+        category: { in: usedCategories },
+        date: { gte: startOfMonth },
+        amount: { lt: 0 },
+      },
+      select: { category: true, amount: true },
+    }),
+    prisma.transaction.findMany({
+      where: { userId, category: { in: usedCategories } },
+      orderBy: { date: "desc" },
+      select: {
+        id: true,
+        name: true,
+        amount: true,
+        date: true,
+        avatar: true,
+        category: true,
+      },
+    }),
+  ]);
+
+  const spentByCategory = Object.fromEntries(
+    usedCategories.map((cat) => [
+      cat,
+      Math.abs(
+        monthTransactions
+          .filter((t) => t.category === cat)
+          .reduce((sum, t) => sum + t.amount, 0),
+      ),
+    ]),
+  ) as Record<Category, number>;
+
+  const latestByCategory = Object.fromEntries(
+    usedCategories.map((cat) => [
+      cat,
+      allCategoryTransactions.filter((t) => t.category === cat).slice(0, 3),
+    ]),
+  ) as Record<
+    Category,
+    { id: string; name: string; amount: number; date: Date; avatar: string }[]
+  >;
 
   return (
     <div className="p-400 lg:p-1000">
@@ -23,7 +73,7 @@ export default async function BudgetsPage() {
           usedCategories={usedCategories}
         />
       </div>
-      {budgets.length === 0 && (
+      {budgets.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-400 rounded-2xl bg-white px-400 py-[80px] text-center">
           <svg
             width="48"
@@ -46,11 +96,13 @@ export default async function BudgetsPage() {
             </p>
           </div>
         </div>
+      ) : (
+        <BudgetList
+          budgets={budgets}
+          spentByCategory={spentByCategory}
+          latestByCategory={latestByCategory}
+        />
       )}
-      <div>
-        {/* Spending Summary */}
-        {/* Budgets List */}
-      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -19,6 +19,33 @@ export default async function BudgetsPage() {
         <h1 className="text-preset-1 text-grey-900">Budgets</h1>
         <AddBudgetModal usedThemes={usedThemes} />
       </div>
+      {budgets.length === 0 && (
+        <div className="flex flex-col items-center justify-center gap-400 rounded-2xl bg-white px-400 py-[80px] text-center">
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+            className="text-grey-300"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+              fill="currentColor"
+            />
+          </svg>
+          <div className="flex flex-col gap-100">
+            <p className="text-preset-2 text-grey-900">No budgets yet</p>
+            <p className="text-preset-4 text-grey-500 max-w-[320px]">
+              Create your first budget to start tracking your spending by category.
+            </p>
+          </div>
+        </div>
+      )}
+      <div>
+        {/* Spending Summary */}
+        {/* Budgets List */}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -52,14 +52,14 @@ export default async function BudgetsPage() {
           .reduce((sum, t) => sum + t.amount, 0),
       ),
     ]),
-  ) as Record<Category, number>;
+  ) as unknown as Record<Category, number>;
 
   const latestByCategory = Object.fromEntries(
     usedCategories.map((cat) => [
       cat,
       allCategoryTransactions.filter((t) => t.category === cat).slice(0, 3),
     ]),
-  ) as Record<
+  ) as unknown as Record<
     Category,
     { id: string; name: string; amount: number; date: Date; avatar: string }[]
   >;

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -22,6 +22,8 @@ interface SelectProps {
   disabled?: boolean;
   id?: string;
   icon?: ReactNode;
+  side?: RadixSelect.SelectContentProps['side'];
+  avoidCollisions?: boolean;
 }
 
 function CaretDown() {
@@ -74,6 +76,8 @@ export function Select({
   disabled,
   id,
   icon,
+  side = 'bottom',
+  avoidCollisions = true,
 }: SelectProps) {
   const selectId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
   const hasError = Boolean(error);
@@ -118,6 +122,8 @@ export function Select({
           <RadixSelect.Content
             position="popper"
             sideOffset={4}
+            side={side}
+            avoidCollisions={avoidCollisions}
             className={cn(
               'z-50 w-[var(--radix-select-trigger-width)] overflow-hidden rounded-lg bg-white shadow-lg',
               'data-[state=open]:animate-in data-[state=closed]:animate-out',
@@ -125,7 +131,7 @@ export function Select({
               'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95'
             )}
           >
-            <RadixSelect.Viewport className="py-100">
+            <RadixSelect.Viewport className="max-h-[240px] overflow-y-auto py-100">
               {options.map((option) => (
                 <RadixSelect.Item
                   key={option.value}

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -1,0 +1,37 @@
+import type { Theme } from "@/generated/prisma/enums";
+
+export const THEME_COLORS: Record<Theme, string> = {
+  Green: "#277c78",
+  Yellow: "#f2cdac",
+  Cyan: "#82c9d7",
+  Navy: "#626070",
+  Red: "#c94736",
+  Purple: "#826cb0",
+  Turquoise: "#597c7c",
+  Brown: "#93674f",
+  Magenta: "#934f6f",
+  Blue: "#3f82b2",
+  NavyGrey: "#97a0ac",
+  ArmyGreen: "#7f9161",
+  Pink: "#af81ba",
+  Gold: "#cab361",
+  Orange: "#be6c49",
+};
+
+export const THEME_LABELS: Record<Theme, string> = {
+  Green: "Green",
+  Yellow: "Yellow",
+  Cyan: "Cyan",
+  Navy: "Navy",
+  Red: "Red",
+  Purple: "Purple",
+  Turquoise: "Turquoise",
+  Brown: "Brown",
+  Magenta: "Magenta",
+  Blue: "Blue",
+  NavyGrey: "Navy Grey",
+  ArmyGreen: "Army Green",
+  Pink: "Pink",
+  Gold: "Gold",
+  Orange: "Orange",
+};

--- a/src/server/actions/budgets.ts
+++ b/src/server/actions/budgets.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { auth } from "@/lib/auth/auth";
+import { prisma } from "@/lib/db/prisma";
+import { Category, Theme } from "@/generated/prisma/enums";
+
+const createBudgetSchema = z.object({
+  category: z.enum(Category),
+  maximum: z.number().positive("Maximum must be greater than zero"),
+  theme: z.enum(Theme),
+});
+
+export type CreateBudgetInput = z.infer<typeof createBudgetSchema>;
+
+export type CreateBudgetResult =
+  | { success: true }
+  | {
+      success: false;
+      fieldErrors?: Partial<Record<keyof CreateBudgetInput, string[]>>;
+    };
+
+export async function createBudget(
+  input: CreateBudgetInput,
+): Promise<CreateBudgetResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const parsed = createBudgetSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      fieldErrors: z.flattenError(parsed.error).fieldErrors as Partial<
+        Record<keyof CreateBudgetInput, string[]>
+      >,
+    };
+  }
+
+  const { category, maximum, theme } = parsed.data;
+
+  try {
+    await prisma.budget.create({
+      data: { category, maximum, theme, userId: session.user.id },
+    });
+  } catch (err) {
+    if (isPrismaUniqueError(err)) {
+      return {
+        success: false,
+        fieldErrors: {
+          category: ["A budget for this category already exists"],
+        },
+      };
+    }
+    throw err;
+  }
+
+  revalidatePath("/budgets");
+  return { success: true };
+}
+
+function isPrismaUniqueError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "P2002"
+  );
+}


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
Implements the budget listing page and the Add Budget modal.

Each budget card shows the category, theme color, a progress bar with current-month spending vs. maximum, spent/remaining stat boxes, and the 3 most recent transactions for that category with a "See All" link to /transactions?category=<category>.

The Add Budget modal prevents duplicate categories (already-budgeted categories are marked in the select) and duplicate themes (already-used themes are visually flagged). A loading skeleton mirrors the card layout while server data loads.

## 🔗 Related issue

Closes #37 
Closes #39 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Navigate to /budgets — verify the loading skeleton appears briefly before the cards render
2. Click + Add New Budget, select a category and theme, enter a maximum, submit — verify the new card appears with the correct color, progress bar, and latest transactions
3. Open the modal again and select the same category used in step 2 — verify it is marked as already used and the server returns an inline error on submit
4. Click See All on any card — verify it navigates to /transactions?category=<correct-category>
5. Create a budget for a category that has no transactions — verify the "No transactions yet" empty state is shown in the Latest Spending section

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [ ] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 01 47" src="https://github.com/user-attachments/assets/c8d003ab-2f61-4b5f-a702-5bb89407b455" />
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 01 15" src="https://github.com/user-attachments/assets/1d3742be-85bf-4ec2-a058-a46068907b4a" />
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 00 32" src="https://github.com/user-attachments/assets/7fe769a7-80c6-4693-9526-6c454e5879a3" />

