### PR TITLE
feat: FIN-52 - Grafico donut de budgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "personal-finance-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.2",
         "@hookform/resolvers": "^5.2.2",
@@ -25,6 +26,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.75.0",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.4.3"
       },
@@ -3436,6 +3438,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3895,7 +3933,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -4910,6 +4947,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4997,6 +5097,12 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -6854,6 +6960,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6962,6 +7189,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -7429,7 +7662,6 @@
       "version": "1.46.1",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
       "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -8089,7 +8321,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/expect-type": {
@@ -8925,6 +9156,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9013,6 +9254,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arguments": {
@@ -11775,9 +12025,31 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -11889,6 +12161,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11914,6 +12216,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11989,6 +12306,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -12946,7 +13269,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -13887,6 +14209,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -13929,6 +14260,28 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.75.0",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.4.3"
   },

--- a/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
@@ -111,7 +111,7 @@ export function BudgetCard({ budget, spent, latestTransactions }: Props) {
                 key={t.id}
                 className={`flex items-center justify-between py-300 ${
                   i < latestTransactions.length - 1
-                    ? "border-grey-100 border-b"
+                    ? "border-grey-500/15 border-b"
                     : ""
                 }`}
               >

--- a/src/app/(dashboard)/budgets/_components/BudgetDonutChart.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetDonutChart.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import type { BudgetModel as Budget } from "@/generated/prisma/models";
+import type { Category, Theme } from "@/generated/prisma/enums";
+import { CATEGORY_LABELS } from "@/lib/categories";
+import { THEME_COLORS } from "@/lib/themes";
+const fmt = (amount: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
+    amount,
+  );
+
+type ChartEntry = {
+  category: Category;
+  label: string;
+  color: string;
+  spent: number;
+  maximum: number;
+  value: number;
+};
+
+type TooltipProps = {
+  active?: boolean;
+  payload?: { payload: ChartEntry }[];
+};
+
+function CustomTooltip({ active, payload }: TooltipProps) {
+  if (!active || !payload?.length || !payload[0]) return null;
+  const item = payload[0].payload;
+  return (
+    <div className="bg-grey-900 rounded-lg px-300 py-200 shadow-md">
+      <p className="text-preset-5-bold text-white">{item.label}</p>
+      <p className="text-preset-5 text-white">{formatCurrency(item.spent)}</p>
+    </div>
+  );
+}
+
+type Props = {
+  budgets: Budget[];
+  spentByCategory: Record<Category, number>;
+};
+
+export function BudgetDonutChart({ budgets, spentByCategory }: Props) {
+  const totalSpent = budgets.reduce(
+    (sum, b) => sum + (spentByCategory[b.category as Category] ?? 0),
+    0,
+  );
+  const totalLimit = budgets.reduce((sum, b) => sum + b.maximum, 0);
+
+  const entries: ChartEntry[] = budgets.map((b) => ({
+    category: b.category as Category,
+    label: CATEGORY_LABELS[b.category as Category],
+    color: THEME_COLORS[b.theme as Theme],
+    spent: spentByCategory[b.category as Category] ?? 0,
+    maximum: b.maximum,
+    value: spentByCategory[b.category as Category] ?? 0,
+  }));
+
+  const hasSpending = totalSpent > 0;
+  const chartData: ChartEntry[] = hasSpending
+    ? entries.filter((e) => e.value > 0)
+    : entries.map((e) => ({ ...e, value: 1 }));
+
+  return (
+    <div className="rounded-2xl bg-white p-500">
+      {/* Donut */}
+      <div className="relative mx-auto mb-400 h-[240px] w-[240px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              innerRadius="65%"
+              outerRadius="85%"
+              dataKey="value"
+              startAngle={90}
+              endAngle={-270}
+              stroke="none"
+            >
+              {chartData.map((entry, i) => (
+                <Cell
+                  key={`cell-${i}`}
+                  fill={hasSpending ? entry.color : "#f2f2f2"}
+                />
+              ))}
+            </Pie>
+            {hasSpending && <Tooltip content={<CustomTooltip />} />}
+          </PieChart>
+        </ResponsiveContainer>
+
+        {/* Center text */}
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-100">
+          <p className="text-preset-1 text-grey-900">
+            {formatCurrency(totalSpent)}
+          </p>
+          <p className="text-preset-5 text-grey-500">
+            of {formatCurrency(totalLimit)} limit
+          </p>
+        </div>
+      </div>
+
+      {/* Spending Summary */}
+      <p className="text-preset-2 text-grey-900 mb-300">Spending Summary</p>
+      <ul>
+        {entries.map((item) => (
+          <li
+            key={item.category}
+            className="border-grey-100 flex items-center justify-between border-b py-300 last:border-none"
+          >
+            <div className="flex items-center gap-200">
+              <span
+                className="h-[21px] w-[4px] shrink-0 rounded-full"
+                style={{ backgroundColor: item.color }}
+                aria-hidden="true"
+              />
+              <span className="text-preset-4 text-grey-500">{item.label}</span>
+            </div>
+            <div className="flex items-center gap-200">
+              <span className="text-preset-4-bold text-grey-900">
+                {formatCurrency(item.spent)}
+              </span>
+              <span className="text-preset-5 text-grey-500">
+                of {formatCurrency(item.maximum)}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/budgets/_components/BudgetDonutChart.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetDonutChart.tsx
@@ -30,7 +30,7 @@ function CustomTooltip({ active, payload }: TooltipProps) {
   return (
     <div className="bg-grey-900 rounded-lg px-300 py-200 shadow-md">
       <p className="text-preset-5-bold text-white">{item.label}</p>
-      <p className="text-preset-5 text-white">{formatCurrency(item.spent)}</p>
+      <p className="text-preset-5 text-white">{fmt(item.spent)}</p>
     </div>
   );
 }
@@ -91,11 +91,9 @@ export function BudgetDonutChart({ budgets, spentByCategory }: Props) {
 
         {/* Center text */}
         <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-100">
-          <p className="text-preset-1 text-grey-900">
-            {formatCurrency(totalSpent)}
-          </p>
+          <p className="text-preset-1 text-grey-900">{fmt(totalSpent)}</p>
           <p className="text-preset-5 text-grey-500">
-            of {formatCurrency(totalLimit)} limit
+            of {fmt(totalLimit)} limit
           </p>
         </div>
       </div>
@@ -118,10 +116,10 @@ export function BudgetDonutChart({ budgets, spentByCategory }: Props) {
             </div>
             <div className="flex items-center gap-200">
               <span className="text-preset-4-bold text-grey-900">
-                {formatCurrency(item.spent)}
+                {fmt(item.spent)}
               </span>
               <span className="text-preset-5 text-grey-500">
-                of {formatCurrency(item.maximum)}
+                of {fmt(item.maximum)}
               </span>
             </div>
           </li>

--- a/src/app/(dashboard)/budgets/_components/BudgetListSkeleton.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetListSkeleton.tsx
@@ -54,6 +54,35 @@ function BudgetCardSkeleton() {
   );
 }
 
+export function BudgetDonutSkeleton() {
+  return (
+    <div className="rounded-2xl bg-white p-500">
+      {/* Donut */}
+      <div className="bg-grey-100 mx-auto mb-400 h-[240px] w-[240px] animate-pulse rounded-full" />
+
+      {/* Spending Summary heading */}
+      <div className="bg-grey-100 mb-300 h-[20px] w-[160px] animate-pulse rounded" />
+
+      {/* Summary rows */}
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          key={i}
+          className="border-grey-100 flex items-center justify-between border-b py-300 last:border-none"
+        >
+          <div className="flex items-center gap-200">
+            <div className="bg-grey-100 h-[21px] w-[4px] animate-pulse rounded-full" />
+            <div className="bg-grey-100 h-[14px] w-[100px] animate-pulse rounded" />
+          </div>
+          <div className="flex items-center gap-200">
+            <div className="bg-grey-100 h-[14px] w-[50px] animate-pulse rounded" />
+            <div className="bg-grey-100 h-[12px] w-[60px] animate-pulse rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function BudgetListSkeleton() {
   return (
     <div className="flex flex-col gap-300">

--- a/src/app/(dashboard)/budgets/loading.tsx
+++ b/src/app/(dashboard)/budgets/loading.tsx
@@ -1,4 +1,7 @@
-import { BudgetListSkeleton } from "./_components/BudgetListSkeleton";
+import {
+  BudgetListSkeleton,
+  BudgetDonutSkeleton,
+} from "./_components/BudgetListSkeleton";
 
 export default function BudgetsLoading() {
   return (
@@ -7,7 +10,10 @@ export default function BudgetsLoading() {
         <h1 className="text-preset-1 text-grey-900">Budgets</h1>
         <div className="bg-grey-900 h-[40px] w-[140px] animate-pulse rounded-lg" />
       </div>
-      <BudgetListSkeleton />
+      <div className="grid grid-cols-1 items-start gap-300 lg:grid-cols-[2fr_3fr]">
+        <BudgetDonutSkeleton />
+        <BudgetListSkeleton />
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/budgets/page.tsx
+++ b/src/app/(dashboard)/budgets/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db/prisma";
 import type { Category } from "@/generated/prisma/enums";
 import { AddBudgetModal } from "./_components/AddBudgetModal";
 import { BudgetList } from "./_components/BudgetList";
+import { BudgetDonutChart } from "./_components/BudgetDonutChart";
 
 export default async function BudgetsPage() {
   const session = await auth();
@@ -97,11 +98,17 @@ export default async function BudgetsPage() {
           </div>
         </div>
       ) : (
-        <BudgetList
-          budgets={budgets}
-          spentByCategory={spentByCategory}
-          latestByCategory={latestByCategory}
-        />
+        <div className="grid grid-cols-1 items-start gap-300 lg:grid-cols-[2fr_3fr]">
+          <BudgetDonutChart
+            budgets={budgets}
+            spentByCategory={spentByCategory}
+          />
+          <BudgetList
+            budgets={budgets}
+            spentByCategory={spentByCategory}
+            latestByCategory={latestByCategory}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
Implements the budget donut chart with a spending summary panel on the left side of the Budgets page.

The donut chart displays one slice per budget category, colored by each budget's theme. The total spent across all categories is shown in the center alongside the total limit. A "Spending Summary" list below the chart shows each category with its spent amount and limit. When no spending exists yet, equal grey slices are rendered as a placeholder so the chart never breaks. A custom tooltip shows the category name and spent amount on hover.

The page layout was updated to a two-column grid on desktop (donut panel left, budget cards right), with a matching skeleton for the loading state.

## 🔗 Related issue

Closes #38 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Navigate to /budgets with at least two budgets that have transactions — verify each slice color matches the budget's theme and the center shows the correct total spent and limit
2. Hover over a slice — verify the tooltip shows the category name and spent amount
3. Navigate to /budgets with budgets that have no transactions — verify the chart renders equal grey slices without errors
4. Throttle the network in DevTools and navigate to /budgets — verify the donut skeleton appears before the real chart loads
5. Resize the browser to mobile width — verify the donut panel stacks above the budget cards

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [ ] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 22 18" src="https://github.com/user-attachments/assets/e7fd3190-0598-4078-961b-dc46aae90115" />
