### PR TITLE
feat: FIN-54 - Modal Edit budget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-select": "^2.2.6",
         "@tanstack/react-query": "^5.100.9",
         "@tanstack/react-query-devtools": "^5.100.9",
@@ -3025,6 +3026,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -3079,6 +3109,46 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3170,6 +3240,37 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.6",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-query-devtools": "^5.100.9",

--- a/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
@@ -4,6 +4,7 @@ import type { Category } from "@/generated/prisma/enums";
 import { CATEGORY_LABELS } from "@/lib/categories";
 import { THEME_COLORS } from "@/lib/themes";
 import { formatCurrency, formatDate, getInitials } from "@/lib/format";
+import { BudgetCardActions } from "./BudgetCardActions";
 
 type Transaction = {
   id: string;
@@ -43,6 +44,7 @@ export function BudgetCard({ budget, spent, latestTransactions }: Props) {
           />
           <h2 className="text-preset-2 text-grey-900">{categoryLabel}</h2>
         </div>
+        <BudgetCardActions budgetId={budget.id} />
       </div>
 
       {/* Maximum */}

--- a/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCard.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { BudgetModel as Budget } from "@/generated/prisma/models";
-import type { Category } from "@/generated/prisma/enums";
+import type { Category, Theme } from "@/generated/prisma/enums";
 import { CATEGORY_LABELS } from "@/lib/categories";
 import { THEME_COLORS } from "@/lib/themes";
 import { formatCurrency, formatDate, getInitials } from "@/lib/format";
@@ -18,6 +18,7 @@ type Props = {
   budget: Budget;
   spent: number;
   latestTransactions: Transaction[];
+  usedThemes: Theme[];
 };
 
 const fmt = (amount: number) =>
@@ -25,7 +26,12 @@ const fmt = (amount: number) =>
     amount,
   );
 
-export function BudgetCard({ budget, spent, latestTransactions }: Props) {
+export function BudgetCard({
+  budget,
+  spent,
+  latestTransactions,
+  usedThemes,
+}: Props) {
   const { category, maximum, theme } = budget;
   const themeColor = THEME_COLORS[theme];
   const remaining = Math.max(0, maximum - spent);
@@ -44,7 +50,7 @@ export function BudgetCard({ budget, spent, latestTransactions }: Props) {
           />
           <h2 className="text-preset-2 text-grey-900">{categoryLabel}</h2>
         </div>
-        <BudgetCardActions budgetId={budget.id} />
+        <BudgetCardActions budget={budget} usedThemes={usedThemes} />
       </div>
 
       {/* Maximum */}

--- a/src/app/(dashboard)/budgets/_components/BudgetCardActions.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCardActions.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { DropdownMenu } from "@/components/ui/DropdownMenu/DropdownMenu";
+
+type Props = {
+  budgetId: string;
+};
+
+export function BudgetCardActions({ budgetId: _budgetId }: Props) {
+  const [_editOpen, setEditOpen] = useState(false);
+  const [_deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu
+        trigger={
+          <button
+            className="text-grey-300 hover:text-grey-500 cursor-pointer rounded p-100 transition-colors"
+            aria-label="Budget options"
+          >
+            <svg
+              width="16"
+              height="4"
+              viewBox="0 0 16 4"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle cx="2" cy="2" r="2" fill="currentColor" />
+              <circle cx="8" cy="2" r="2" fill="currentColor" />
+              <circle cx="14" cy="2" r="2" fill="currentColor" />
+            </svg>
+          </button>
+        }
+        items={[
+          { label: "Edit Budget", onClick: () => setEditOpen(true) },
+          {
+            label: "Delete Budget",
+            onClick: () => setDeleteOpen(true),
+            destructive: true,
+          },
+        ]}
+      />
+      {/* EditBudgetModal — FIN-54 */}
+      {/* DeleteBudgetModal — FIN-55 */}
+    </>
+  );
+}

--- a/src/app/(dashboard)/budgets/_components/BudgetCardActions.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetCardActions.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import { useState } from "react";
+import type { Theme } from "@/generated/prisma/enums";
+import type { BudgetModel as Budget } from "@/generated/prisma/models";
 import { DropdownMenu } from "@/components/ui/DropdownMenu/DropdownMenu";
+import { EditBudgetModal } from "./EditBudgetModal";
 
 type Props = {
-  budgetId: string;
+  budget: Budget;
+  usedThemes: Theme[];
 };
 
-export function BudgetCardActions({ budgetId: _budgetId }: Props) {
-  const [_editOpen, setEditOpen] = useState(false);
+export function BudgetCardActions({ budget, usedThemes }: Props) {
+  const [editOpen, setEditOpen] = useState(false);
   const [_deleteOpen, setDeleteOpen] = useState(false);
 
   return (
@@ -41,7 +45,12 @@ export function BudgetCardActions({ budgetId: _budgetId }: Props) {
           },
         ]}
       />
-      {/* EditBudgetModal — FIN-54 */}
+      <EditBudgetModal
+        budget={budget}
+        usedThemes={usedThemes}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+      />
       {/* DeleteBudgetModal — FIN-55 */}
     </>
   );

--- a/src/app/(dashboard)/budgets/_components/BudgetList.tsx
+++ b/src/app/(dashboard)/budgets/_components/BudgetList.tsx
@@ -1,5 +1,5 @@
 import type { BudgetModel as Budget } from "@/generated/prisma/models";
-import type { Category } from "@/generated/prisma/enums";
+import type { Category, Theme } from "@/generated/prisma/enums";
 import { BudgetCard } from "./BudgetCard";
 
 type Transaction = {
@@ -21,6 +21,8 @@ export function BudgetList({
   spentByCategory,
   latestByCategory,
 }: Props) {
+  const usedThemes = budgets.map((b) => b.theme as Theme);
+
   return (
     <div className="flex flex-col gap-300">
       {budgets.map((budget) => (
@@ -31,6 +33,7 @@ export function BudgetList({
           latestTransactions={
             latestByCategory[budget.category as Category] ?? []
           }
+          usedThemes={usedThemes}
         />
       ))}
     </div>

--- a/src/app/(dashboard)/budgets/_components/EditBudgetModal.tsx
+++ b/src/app/(dashboard)/budgets/_components/EditBudgetModal.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { CATEGORY_LABELS } from "@/lib/categories";
+import { THEME_COLORS, THEME_LABELS } from "@/lib/themes";
+import type { Category, Theme } from "@/generated/prisma/enums";
+import type { BudgetModel as Budget } from "@/generated/prisma/models";
+import { updateBudget } from "@/server/actions/budgets";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+  maximum: z
+    .string()
+    .min(1, "Maximum is required")
+    .refine((v) => !isNaN(Number(v)), "Must be a valid number")
+    .refine((v) => Number(v) > 0, "Maximum must be greater than zero"),
+  theme: z.string().min(1, "Select a theme"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type Props = {
+  budget: Budget;
+  usedThemes: Theme[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function EditBudgetModal({
+  budget,
+  usedThemes,
+  open,
+  onOpenChange,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const themeOptions = Object.entries(THEME_LABELS).map(([value, label]) => ({
+    value,
+    label,
+    color: THEME_COLORS[value as Theme],
+    alreadyUsed: usedThemes.includes(value as Theme) && value !== budget.theme,
+  }));
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    values: {
+      maximum: String(budget.maximum),
+      theme: budget.theme,
+    },
+  });
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  function onSubmit(data: FormValues) {
+    startTransition(async () => {
+      const result = await updateBudget({
+        id: budget.id,
+        maximum: Number(data.maximum),
+        theme: data.theme as Theme,
+      });
+
+      if (result.success) {
+        handleOpenChange(false);
+        router.refresh();
+        return;
+      }
+
+      for (const [field, messages] of Object.entries(
+        result.fieldErrors ?? {},
+      )) {
+        if (messages?.length) {
+          setError(field as keyof FormValues, { message: messages[0] });
+        }
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Edit Budget"
+      description="As your budgets change, feel free to update your spending limits."
+      footer={
+        <Button type="submit" form="edit-budget-form" loading={isPending}>
+          Save Changes
+        </Button>
+      }
+    >
+      <form
+        id="edit-budget-form"
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col gap-400 pb-100"
+        noValidate
+      >
+        <Input
+          label="Budget Category"
+          value={CATEGORY_LABELS[budget.category as Category]}
+          disabled
+          readOnly
+        />
+
+        <Input
+          label="Maximum Spend"
+          type="number"
+          step="0.01"
+          placeholder="e.g. 2000"
+          prefix="$"
+          error={errors.maximum?.message}
+          {...register("maximum")}
+        />
+
+        <Controller
+          control={control}
+          name="theme"
+          render={({ field }) => (
+            <Select
+              label="Theme"
+              placeholder="Select a theme"
+              options={themeOptions}
+              value={field.value}
+              onValueChange={field.onChange}
+              error={errors.theme?.message}
+              avoidCollisions={false}
+            />
+          )}
+        />
+      </form>
+    </Dialog>
+  );
+}

--- a/src/components/ui/Dialog/Dialog.tsx
+++ b/src/components/ui/Dialog/Dialog.tsx
@@ -1,12 +1,12 @@
-'use client';
+"use client";
 
-import * as RadixDialog from '@radix-ui/react-dialog';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
-import { CloseIcon } from '@/components/ui/icons/CloseIcon';
-import { cn } from '@/lib/cn';
+import * as RadixDialog from "@radix-ui/react-dialog";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { CloseIcon } from "@/components/ui/icons/CloseIcon";
+import { cn } from "@/lib/cn";
 
 interface DialogProps extends RadixDialog.DialogProps {
-  trigger: ReactNode;
+  trigger?: ReactNode;
   title: string;
   description?: string;
   children: ReactNode;
@@ -28,7 +28,7 @@ export function Dialog({
 }: DialogProps) {
   return (
     <RadixDialog.Root {...props}>
-      <RadixDialog.Trigger asChild>{trigger}</RadixDialog.Trigger>
+      {trigger && <RadixDialog.Trigger asChild>{trigger}</RadixDialog.Trigger>}
       <DialogContent className={contentClassName}>
         <DialogHeader>
           <RadixDialog.Title className="text-preset-2 text-grey-900 pr-800">
@@ -49,32 +49,39 @@ export function Dialog({
   );
 }
 
-export function DialogContent({ className, children, ...props }: DialogContentProps) {
+export function DialogContent({
+  className,
+  children,
+  ...props
+}: DialogContentProps) {
   return (
     <RadixDialog.Portal>
       <RadixDialog.Overlay
         data-testid="dialog-overlay"
         className={cn(
-          'bg-grey-900/45 fixed inset-0 z-50 [will-change:opacity]',
-          'data-[state=open]:animate-[dialog-overlay-show_150ms_ease-out]',
-          'data-[state=closed]:animate-[dialog-overlay-hide_150ms_ease-in]'
+          "bg-grey-900/45 fixed inset-0 z-50 [will-change:opacity]",
+          "data-[state=open]:animate-[dialog-overlay-show_150ms_ease-out]",
+          "data-[state=closed]:animate-[dialog-overlay-hide_150ms_ease-in]",
         )}
       />
       <RadixDialog.Content
         aria-modal="true"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 w-[calc(100vw-2rem)] max-w-[35rem]',
-          'max-h-[calc(100vh-2rem)] [translate:-50%_-50%] overflow-hidden',
-          'rounded-lg bg-white shadow-xl focus:outline-none',
-          '[will-change:opacity,translate,scale]',
-          'data-[state=open]:animate-[dialog-content-show_180ms_ease-out]',
-          'data-[state=closed]:animate-[dialog-content-hide_150ms_ease-in]',
-          className
+          "fixed top-1/2 left-1/2 z-50 w-[calc(100vw-2rem)] max-w-[35rem]",
+          "max-h-[calc(100vh-2rem)] [translate:-50%_-50%] overflow-hidden",
+          "rounded-lg bg-white shadow-xl focus:outline-none",
+          "[will-change:opacity,translate,scale]",
+          "data-[state=open]:animate-[dialog-content-show_180ms_ease-out]",
+          "data-[state=closed]:animate-[dialog-content-hide_150ms_ease-in]",
+          className,
         )}
         {...props}
       >
         {children}
-        <DialogClose className="absolute top-500 right-500" aria-label="Close dialog">
+        <DialogClose
+          className="absolute top-500 right-500"
+          aria-label="Close dialog"
+        >
           <CloseIcon />
         </DialogClose>
       </RadixDialog.Content>
@@ -82,31 +89,53 @@ export function DialogContent({ className, children, ...props }: DialogContentPr
   );
 }
 
-export function DialogHeader({ className, ...props }: ComponentPropsWithoutRef<'header'>) {
-  return <header className={cn('flex flex-col gap-200 p-600 pb-500', className)} {...props} />;
-}
-
-export function DialogBody({ className, ...props }: ComponentPropsWithoutRef<'div'>) {
+export function DialogHeader({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"header">) {
   return (
-    <div
-      className={cn('text-preset-4 text-grey-500 max-h-[50vh] overflow-y-auto px-600', className)}
+    <header
+      className={cn("flex flex-col gap-200 p-600 pb-500", className)}
       {...props}
     />
   );
 }
 
-export function DialogFooter({ className, ...props }: ComponentPropsWithoutRef<'footer'>) {
-  return <footer className={cn('flex flex-col-reverse gap-300 p-600', className)} {...props} />;
+export function DialogBody({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "text-preset-4 text-grey-500 max-h-[50vh] overflow-y-auto px-600",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function DialogFooter({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"footer">) {
+  return (
+    <footer
+      className={cn("flex flex-col-reverse gap-300 p-600", className)}
+      {...props}
+    />
+  );
 }
 
 export function DialogClose({ className, ...props }: DialogCloseProps) {
   return (
     <RadixDialog.Close
       className={cn(
-        'text-grey-500 hover:text-grey-900 inline-flex cursor-pointer items-center justify-center',
-        'rounded-lg transition-colors duration-150',
-        'focus-visible:ring-grey-900 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
-        className
+        "text-grey-500 hover:text-grey-900 inline-flex cursor-pointer items-center justify-center",
+        "rounded-lg transition-colors duration-150",
+        "focus-visible:ring-grey-900 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+        className,
       )}
       {...props}
     />

--- a/src/components/ui/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/ui/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DropdownMenu } from "./DropdownMenu";
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: "UI/DropdownMenu",
+  component: DropdownMenu,
+  tags: ["autodocs"],
+  parameters: { backgrounds: { default: "light" } },
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex justify-center p-600">
+      <DropdownMenu
+        trigger={
+          <button
+            type="button"
+            className="text-grey-500 hover:text-grey-900 rounded p-100 transition-colors"
+            aria-label="Options"
+          >
+            ···
+          </button>
+        }
+        items={[
+          { label: "Edit Budget", onClick: () => {} },
+          { label: "Delete Budget", onClick: () => {}, destructive: true },
+        ]}
+      />
+    </div>
+  ),
+};
+
+export const WithoutDestructive: Story = {
+  render: () => (
+    <div className="flex justify-center p-600">
+      <DropdownMenu
+        trigger={
+          <button
+            type="button"
+            className="text-grey-500 hover:text-grey-900 rounded p-100 transition-colors"
+            aria-label="Options"
+          >
+            ···
+          </button>
+        }
+        items={[
+          { label: "Edit Pot", onClick: () => {} },
+          { label: "Delete Pot", onClick: () => {}, destructive: true },
+        ]}
+      />
+    </div>
+  ),
+};

--- a/src/components/ui/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/ui/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DropdownMenu } from "./DropdownMenu";
+
+function TestDropdown({
+  onEdit = vi.fn(),
+  onDelete = vi.fn(),
+}: {
+  onEdit?: () => void;
+  onDelete?: () => void;
+}) {
+  return (
+    <DropdownMenu
+      trigger={<button type="button">Open menu</button>}
+      items={[
+        { label: "Edit Budget", onClick: onEdit },
+        { label: "Delete Budget", onClick: onDelete, destructive: true },
+      ]}
+    />
+  );
+}
+
+describe("DropdownMenu", () => {
+  it("renders the trigger and keeps menu hidden initially", () => {
+    render(<TestDropdown />);
+
+    expect(
+      screen.getByRole("button", { name: "Open menu" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("opens the menu when trigger is clicked", async () => {
+    const user = userEvent.setup();
+    render(<TestDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Edit Budget" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete Budget" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls the item callback when a menu item is clicked", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    render(<TestDropdown onEdit={onEdit} />);
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Edit Budget" }));
+
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it("calls the destructive item callback when delete is clicked", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<TestDropdown onDelete={onDelete} />);
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Delete Budget" }));
+
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("closes the menu after selecting an item", async () => {
+    const user = userEvent.setup();
+    render(<TestDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Edit Budget" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes the menu when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    render(<TestDropdown />);
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("returns focus to the trigger after closing", async () => {
+    const user = userEvent.setup();
+    render(<TestDropdown />);
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+});

--- a/src/components/ui/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as RadixDropdown from "@radix-ui/react-dropdown-menu";
+import { Fragment, type ReactNode } from "react";
+
+export type DropdownItem = {
+  label: string;
+  onClick: () => void;
+  destructive?: boolean;
+};
+
+type Props = {
+  trigger: ReactNode;
+  items: DropdownItem[];
+};
+
+export function DropdownMenu({ trigger, items }: Props) {
+  return (
+    <RadixDropdown.Root>
+      <RadixDropdown.Trigger asChild>{trigger}</RadixDropdown.Trigger>
+      <RadixDropdown.Portal>
+        <RadixDropdown.Content
+          className="z-50 w-[168px] rounded-xl bg-white py-100 shadow-[0_4px_24px_rgba(0,0,0,0.25)]"
+          align="end"
+          sideOffset={4}
+        >
+          {items.map((item, i) => (
+            <Fragment key={item.label}>
+              {i > 0 && (
+                <RadixDropdown.Separator className="bg-grey-100 mx-400 my-100 h-px" />
+              )}
+              <RadixDropdown.Item
+                className={`text-preset-4 mx-100 cursor-pointer rounded-lg px-300 py-200 transition-colors outline-none select-none ${
+                  item.destructive
+                    ? "text-red focus:bg-red/10"
+                    : "text-grey-900 focus:bg-grey-100"
+                }`}
+                onSelect={item.onClick}
+              >
+                {item.label}
+              </RadixDropdown.Item>
+            </Fragment>
+          ))}
+        </RadixDropdown.Content>
+      </RadixDropdown.Portal>
+    </RadixDropdown.Root>
+  );
+}

--- a/src/components/ui/DropdownMenu/index.ts
+++ b/src/components/ui/DropdownMenu/index.ts
@@ -1,0 +1,2 @@
+export { DropdownMenu } from "./DropdownMenu";
+export type { DropdownItem } from "./DropdownMenu";

--- a/src/server/actions/budgets.ts
+++ b/src/server/actions/budgets.ts
@@ -61,6 +61,52 @@ export async function createBudget(
   return { success: true };
 }
 
+const updateBudgetSchema = z.object({
+  id: z.string().min(1),
+  maximum: z.number().positive("Maximum must be greater than zero"),
+  theme: z.enum(Theme),
+});
+
+export type UpdateBudgetInput = z.infer<typeof updateBudgetSchema>;
+
+export type UpdateBudgetResult =
+  | { success: true }
+  | {
+      success: false;
+      fieldErrors?: Partial<
+        Record<keyof Omit<UpdateBudgetInput, "id">, string[]>
+      >;
+    };
+
+export async function updateBudget(
+  input: UpdateBudgetInput,
+): Promise<UpdateBudgetResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const parsed = updateBudgetSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      fieldErrors: z.flattenError(parsed.error).fieldErrors as Partial<
+        Record<keyof Omit<UpdateBudgetInput, "id">, string[]>
+      >,
+    };
+  }
+
+  const { id, maximum, theme } = parsed.data;
+
+  await prisma.budget.update({
+    where: { id, userId: session.user.id },
+    data: { maximum, theme },
+  });
+
+  revalidatePath("/budgets");
+  return { success: true };
+}
+
 function isPrismaUniqueError(err: unknown): boolean {
   return (
     typeof err === "object" &&


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
Implements the Edit Budget modal, accessible via the three-dot menu on each budget card.

The form opens pre-populated with the budget's current maximum and theme. Category is displayed as a read-only field since it is the unique identifier for a budget. The theme select marks themes already used by other budgets as unavailable, but keeps the current budget's own theme selectable. Validation errors are shown inline without closing the modal.

trigger was made optional in the Dialog component to support fully controlled usage where the open state is managed externally.

## 🔗 Related issue

Closes #40 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Open a budget card, click the ··· menu, and select Edit Budget — verify the form opens with the current maximum and theme pre-filled and the category field is disabled
2. Change the maximum and theme and click Save Changes — verify the card updates with the new values
3. Try selecting a theme already used by another budget — verify it is marked as already used
4. Submit with an empty maximum — verify the inline validation error appears without closing the modal
5. Press Escape or click outside the modal — verify it closes and the form resets to the original values on next open

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [x] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 41 09" src="https://github.com/user-attachments/assets/8a54bcd0-b43c-4c8e-b91a-8aed7a7b8773" />
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 41 03" src="https://github.com/user-attachments/assets/67919b99-bc01-466b-b650-32d6c7b4b56c" />
<img width="1418" height="829" alt="Screenshot 2026-05-27 at 03 40 57" src="https://github.com/user-attachments/assets/962b3103-2f3b-426f-a08d-dc765fc93cdd" />
