### PR TITLE
feat: FIN-60 — Prisma schema for Pot model with migration

### DIFF
--- a/prisma/migrations/20260527073517_fin_60_pot_schema/migration.sql
+++ b/prisma/migrations/20260527073517_fin_60_pot_schema/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Pot" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "target" DOUBLE PRECISION NOT NULL,
+    "total" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "theme" "Theme" NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Pot_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Pot" ADD CONSTRAINT "Pot_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model User {
   sessions     Session[]
   transactions Transaction[]
   budgets      Budget[]
+  pots         Pot[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -84,6 +85,20 @@ model Transaction {
   category  Category
   recurring Boolean  @default(false)
   avatar    String
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Pot {
+  id     String @id @default(cuid())
+  name   String
+  target Float
+  total  Float  @default(0)
+  theme  Theme
 
   userId String
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
Adds the Pot model to the Prisma schema and applies the database migration.

The model stores name, target, total (defaults to 0), and theme per user. total >= 0 and total <= target are enforced at the application layer (server actions) since Prisma does not support native CHECK constraints — the schema keeps the data layer simple and delegates business rules to the action layer.

## 🔗 Related issue

Closes #48 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1.  Run npx prisma migrate deploy — verify the migration applies without errors
2. Run npm run build — verify the build passes with the new generated client
3. Inspect the Pot table in the database — verify columns id, name, target, total, theme, userId, createdAt, updatedAt exist

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [ ] I added / updated tests
- [ ] Existing tests pass locally
- [x] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
