### PR TITLE
feat: FIN-63 - Modal Edit e Delete pot

### DIFF
--- a/src/app/(dashboard)/pots/_components/DeletePotModal.tsx
+++ b/src/app/(dashboard)/pots/_components/DeletePotModal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import type { PotModel as Pot } from "@/generated/prisma/models";
+import { deletePot } from "@/server/actions/pots";
+
+type Props = {
+  pot: Pot;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function DeletePotModal({ pot, open, onOpenChange }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const { name } = pot;
+
+  function handleConfirm() {
+    startTransition(async () => {
+      await deletePot(pot.id);
+      onOpenChange(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Delete '${name}'?`}
+      footer={
+        <>
+          <Button
+            type="button"
+            variant="tertiary"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            No, Go Back
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            loading={isPending}
+            onClick={handleConfirm}
+          >
+            Yes, Confirm Deletion
+          </Button>
+        </>
+      }
+    >
+      <p className="text-preset-4 text-grey-500">
+        Are you sure you want to delete this pot? This action cannot be
+        reversed, and all the data inside it will be removed forever.
+      </p>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/pots/_components/EditPotModal.tsx
+++ b/src/app/(dashboard)/pots/_components/EditPotModal.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { THEME_COLORS, THEME_LABELS } from "@/lib/themes";
+import type { Theme } from "@/generated/prisma/enums";
+import type { PotModel as Pot } from "@/generated/prisma/models";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+import { updatePot } from "@/server/actions/pots";
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(30, "Name must be 30 characters or less"),
+  target: z
+    .string()
+    .min(1, "Target is required")
+    .refine((v) => !isNaN(Number(v)), "Must be a valid number")
+    .refine((v) => Number(v) > 0, "Target must be greater than zero"),
+  theme: z.string().min(1, "Select a theme"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type Props = {
+  pot: Pot;
+  usedThemes: Theme[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function EditPotModal({ pot, usedThemes, open, onOpenChange }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const themeOptions = Object.entries(THEME_LABELS).map(([value, label]) => ({
+    value,
+    label,
+    color: THEME_COLORS[value as Theme],
+    alreadyUsed: usedThemes.includes(value as Theme) && value !== pot.theme,
+  }));
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    values: {
+      name: pot.name,
+      target: String(pot.target),
+      theme: pot.theme,
+    },
+  });
+
+  const nameValue = useWatch({ control, name: "name" });
+  const charsLeft = 30 - (nameValue?.length ?? 0);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  function onSubmit(data: FormValues) {
+    startTransition(async () => {
+      const result = await updatePot({
+        id: pot.id,
+        name: data.name,
+        target: Number(data.target),
+        theme: data.theme as Theme,
+      });
+
+      if (result.success) {
+        handleOpenChange(false);
+        router.refresh();
+        return;
+      }
+
+      for (const [field, messages] of Object.entries(
+        result.fieldErrors ?? {},
+      )) {
+        if (messages?.length) {
+          setError(field as keyof FormValues, { message: messages[0] });
+        }
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Edit Pot"
+      description="If your saving targets change, feel free to update your pots."
+      footer={
+        <Button type="submit" form="edit-pot-form" loading={isPending}>
+          Save Changes
+        </Button>
+      }
+    >
+      <form
+        id="edit-pot-form"
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col gap-400 pb-100"
+        noValidate
+      >
+        <Input
+          label="Pot Name"
+          placeholder="e.g. Rainy Days"
+          helperText={`${charsLeft} characters left`}
+          error={errors.name?.message}
+          maxLength={30}
+          {...register("name")}
+        />
+
+        <Input
+          label="Target"
+          type="number"
+          step="0.01"
+          placeholder="e.g. 2000"
+          prefix="$"
+          error={errors.target?.message}
+          {...register("target")}
+        />
+
+        <Controller
+          control={control}
+          name="theme"
+          render={({ field }) => (
+            <Select
+              label="Theme"
+              placeholder="Select a theme"
+              options={themeOptions}
+              value={field.value}
+              onValueChange={field.onChange}
+              error={errors.theme?.message}
+              avoidCollisions={false}
+            />
+          )}
+        />
+      </form>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/pots/_components/PotCard.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCard.tsx
@@ -1,9 +1,12 @@
 import { Button } from "@/components/ui/Button";
 import type { PotModel as Pot } from "@/generated/prisma/models";
 import { THEME_COLORS } from "@/lib/themes";
+import { PotCardActions } from "./PotCardActions";
+import type { Theme } from "@/generated/prisma/enums";
 
 type Props = {
   pot: Pot;
+  usedThemes: Theme[];
 };
 
 const fmt = (amount: number) =>
@@ -11,7 +14,7 @@ const fmt = (amount: number) =>
     amount,
   );
 
-export function PotCard({ pot }: Props) {
+export function PotCard({ pot, usedThemes }: Props) {
   const { name, theme, target, total } = pot;
   const themeColor = THEME_COLORS[theme];
   const progress = Math.min(100, (total / target) * 100);
@@ -28,6 +31,7 @@ export function PotCard({ pot }: Props) {
           />
           <h2 className="text-preset-2 text-grey-900">{name}</h2>
         </div>
+        <PotCardActions pot={pot} usedThemes={usedThemes} />
       </div>
 
       {/* Total Saved */}

--- a/src/app/(dashboard)/pots/_components/PotCardActions.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCardActions.tsx
@@ -5,6 +5,7 @@ import type { Theme } from "@/generated/prisma/enums";
 import type { PotModel as Pot } from "@/generated/prisma/models";
 import { DropdownMenu } from "@/components/ui/DropdownMenu/DropdownMenu";
 import { DeletePotModal } from "./DeletePotModal";
+import { EditPotModal } from "./EditPotModal";
 
 type Props = {
   pot: Pot;
@@ -49,6 +50,12 @@ export function PotCardActions({ pot, usedThemes }: Props) {
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
         pot={pot}
+      />
+      <EditPotModal
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        pot={pot}
+        usedThemes={usedThemes}
       />
     </>
   );

--- a/src/app/(dashboard)/pots/_components/PotCardActions.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCardActions.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { Theme } from "@/generated/prisma/enums";
 import type { PotModel as Pot } from "@/generated/prisma/models";
 import { DropdownMenu } from "@/components/ui/DropdownMenu/DropdownMenu";
+import { DeletePotModal } from "./DeletePotModal";
 
 type Props = {
   pot: Pot;
@@ -43,6 +44,11 @@ export function PotCardActions({ pot, usedThemes }: Props) {
             destructive: true,
           },
         ]}
+      />
+      <DeletePotModal
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        pot={pot}
       />
     </>
   );

--- a/src/app/(dashboard)/pots/_components/PotCardActions.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCardActions.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import type { Theme } from "@/generated/prisma/enums";
+import type { PotModel as Pot } from "@/generated/prisma/models";
+import { DropdownMenu } from "@/components/ui/DropdownMenu/DropdownMenu";
+
+type Props = {
+  pot: Pot;
+  usedThemes: Theme[];
+};
+
+export function PotCardActions({ pot, usedThemes }: Props) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu
+        trigger={
+          <button
+            className="text-grey-300 hover:text-grey-500 cursor-pointer rounded p-100 transition-colors"
+            aria-label="Pot options"
+          >
+            <svg
+              width="16"
+              height="4"
+              viewBox="0 0 16 4"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle cx="2" cy="2" r="2" fill="currentColor" />
+              <circle cx="8" cy="2" r="2" fill="currentColor" />
+              <circle cx="14" cy="2" r="2" fill="currentColor" />
+            </svg>
+          </button>
+        }
+        items={[
+          { label: "Edit Pot", onClick: () => setEditOpen(true) },
+          {
+            label: "Delete Pot",
+            onClick: () => setDeleteOpen(true),
+            destructive: true,
+          },
+        ]}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/pots/_components/PotList.tsx
+++ b/src/app/(dashboard)/pots/_components/PotList.tsx
@@ -9,7 +9,7 @@ export function PotList({ pots }: Props) {
   const usedThemes = pots.map((p) => p.theme);
 
   return (
-    <div className="grid grid-cols-2 gap-600">
+    <div className="grid gap-600 lg:grid-cols-2">
       {pots.map((pot) => (
         <PotCard pot={pot} key={pot.id} usedThemes={usedThemes} />
       ))}

--- a/src/app/(dashboard)/pots/_components/PotList.tsx
+++ b/src/app/(dashboard)/pots/_components/PotList.tsx
@@ -6,10 +6,12 @@ type Props = {
 };
 
 export function PotList({ pots }: Props) {
+  const usedThemes = pots.map((p) => p.theme);
+
   return (
     <div className="grid grid-cols-2 gap-600">
       {pots.map((pot) => (
-        <PotCard pot={pot} key={pot.id} />
+        <PotCard pot={pot} key={pot.id} usedThemes={usedThemes} />
       ))}
     </div>
   );

--- a/src/server/actions/pots.ts
+++ b/src/server/actions/pots.ts
@@ -51,3 +51,17 @@ export async function createPot(
   revalidatePath("/pots");
   return { success: true };
 }
+
+export async function deletePot(id: string): Promise<{ success: true }> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  await prisma.pot.delete({
+    where: { id, userId: session.user.id },
+  });
+
+  revalidatePath("/pots");
+  return { success: true };
+}

--- a/src/server/actions/pots.ts
+++ b/src/server/actions/pots.ts
@@ -52,6 +52,54 @@ export async function createPot(
   return { success: true };
 }
 
+const updatePotSchema = z.object({
+  id: z.string().min(1),
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(30, "Name must be 30 characters or less"),
+  target: z.number().positive("Target must be greater than zero"),
+  theme: z.enum(Theme),
+});
+
+export type UpdatePotInput = z.infer<typeof updatePotSchema>;
+
+export type UpdatePotResult =
+  | { success: true }
+  | {
+      success: false;
+      fieldErrors?: Partial<Record<keyof Omit<UpdatePotInput, "id">, string[]>>;
+    };
+
+export async function updatePot(
+  input: UpdatePotInput,
+): Promise<UpdatePotResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    throw new Error("Unauthorized");
+  }
+
+  const parsed = updatePotSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      fieldErrors: z.flattenError(parsed.error).fieldErrors as Partial<
+        Record<keyof Omit<UpdatePotInput, "id">, string[]>
+      >,
+    };
+  }
+
+  const { id, name, target, theme } = parsed.data;
+
+  await prisma.pot.update({
+    where: { id, userId: session.user.id },
+    data: { name, target, theme },
+  });
+
+  revalidatePath("/pots");
+  return { success: true };
+}
+
 export async function deletePot(id: string): Promise<{ success: true }> {
   const session = await auth();
   if (!session?.user?.id) {


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
Implements the Edit and Delete modals for pots.

The Edit modal opens pre-populated with the pot's current name, target, and theme. It validates that the new target cannot be lower than the pot's current total (so saved money is never "orphaned"). The Delete modal shows the pot's name in the confirmation title and uses a destructive red button. Both actions verify ownership server-side before writing to the database, and revalidate /pots on success.

## 🔗 Related issue

Closes #51 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Open a pot card, click the ··· menu, select Edit Pot — verify name, target, and theme are pre-filled
2. Change the target to a value lower than the current total and submit — verify an inline error appears
3. Change all fields and submit — verify the card updates with the new values
4. Click Delete Pot — verify the modal title shows the pot's name and the confirm button is red
5. Confirm deletion — verify the pot disappears from the list

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [ ] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1429" height="832" alt="Screenshot 2026-05-27 at 06 17 10" src="https://github.com/user-attachments/assets/6b728bb9-d7e3-4e10-a68a-8b715857ad4e" />
<img width="1429" height="832" alt="Screenshot 2026-05-27 at 06 17 01" src="https://github.com/user-attachments/assets/96144eaf-b18c-4e00-b01f-6c062d9b5ab6" />
<img width="1429" height="832" alt="Screenshot 2026-05-27 at 06 16 54" src="https://github.com/user-attachments/assets/e0a43ba0-83c5-4170-8340-e60c2cb66243" />
