### PR TITLE
feat: FIN-64 - Modal Add money to pot

### DIFF
--- a/src/app/(dashboard)/pots/_components/AddMoneyModal.tsx
+++ b/src/app/(dashboard)/pots/_components/AddMoneyModal.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { THEME_COLORS } from "@/lib/themes";
+import type { PotModel as Pot } from "@/generated/prisma/models";
+import { addMoneyToPot } from "@/server/actions/pots";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+
+const formSchema = z.object({
+  amount: z
+    .string()
+    .min(1, "Amount is required")
+    .refine((v) => !isNaN(Number(v)), "Must be a valid number")
+    .refine((v) => Number(v) > 0, "Amount must be greater than zero"),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+const fmt = (amount: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
+    amount,
+  );
+
+type Props = {
+  pot: Pot;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function AddMoneyModal({ pot, open, onOpenChange }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const themeColor = THEME_COLORS[pot.theme];
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    setError,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { amount: "" },
+  });
+
+  const amountValue = useWatch({ control, name: "amount" });
+  const parsedAmount = Number(amountValue) || 0;
+  const newTotal = Math.min(pot.total + parsedAmount, pot.target);
+  const currentProgress = (pot.total / pot.target) * 100;
+  const addedProgress = ((newTotal - pot.total) / pot.target) * 100;
+  const totalProgress = Math.min(100, currentProgress + addedProgress);
+  const wouldExceed = parsedAmount > 0 && pot.total + parsedAmount > pot.target;
+
+  function handleOpenChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  function onSubmit(data: FormValues) {
+    startTransition(async () => {
+      const result = await addMoneyToPot({
+        id: pot.id,
+        amount: Number(data.amount),
+      });
+
+      if (result.success) {
+        handleOpenChange(false);
+        router.refresh();
+        return;
+      }
+
+      if (result.error) {
+        setError("amount", { message: result.error });
+      }
+    });
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title={`Add to '${pot.name}'`}
+      description="Add money to your pot to keep it separate from your main balance. As soon as you add this money, it will be deducted from your current balance."
+      footer={
+        <Button
+          type="submit"
+          form="add-money-form"
+          loading={isPending}
+          disabled={wouldExceed || isPending}
+        >
+          Confirm Addition
+        </Button>
+      }
+    >
+      <form
+        id="add-money-form"
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col gap-400 pb-100"
+        noValidate
+      >
+        {/* Progress preview */}
+        <div>
+          <div className="mb-300 flex items-center justify-between">
+            <p className="text-preset-4 text-grey-500">New Amount</p>
+            <p className="text-preset-1 text-grey-900">{fmt(newTotal)}</p>
+          </div>
+
+          <div className="bg-beige-100 mb-300 h-[8px] w-full overflow-hidden rounded-full">
+            <div className="flex h-full overflow-hidden rounded-full">
+              <div
+                className="h-full rounded-l-full"
+                style={{
+                  backgroundColor: "#201f24",
+                  width: `${currentProgress}%`,
+                }}
+              />
+              {addedProgress > 0 && (
+                <div
+                  className="h-full"
+                  style={{
+                    backgroundColor: themeColor,
+                    width: `${addedProgress}%`,
+                    borderRadius:
+                      totalProgress >= 100 ? "0 9999px 9999px 0" : "0",
+                  }}
+                />
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <p className="text-preset-5-bold" style={{ color: themeColor }}>
+              {totalProgress.toFixed(2)}%
+            </p>
+            <p className="text-preset-5 text-grey-500">
+              Target of {fmt(pot.target)}
+            </p>
+          </div>
+        </div>
+
+        <Input
+          label="Amount to Add"
+          type="number"
+          step="0.01"
+          placeholder="e.g. 100"
+          prefix="$"
+          error={errors.amount?.message}
+          {...register("amount")}
+        />
+      </form>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/pots/_components/PotCard.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCard.tsx
@@ -1,8 +1,12 @@
+"use client";
+
+import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import type { PotModel as Pot } from "@/generated/prisma/models";
 import { THEME_COLORS } from "@/lib/themes";
 import { PotCardActions } from "./PotCardActions";
 import type { Theme } from "@/generated/prisma/enums";
+import { AddMoneyModal } from "./AddMoneyModal";
 
 type Props = {
   pot: Pot;
@@ -18,6 +22,7 @@ export function PotCard({ pot, usedThemes }: Props) {
   const { name, theme, target, total } = pot;
   const themeColor = THEME_COLORS[theme];
   const progress = Math.min(100, (total / target) * 100);
+  const [addMoneyOpen, setAddMoneyOpen] = useState(false);
 
   return (
     <div className="rounded-2xl bg-white p-500">
@@ -35,7 +40,6 @@ export function PotCard({ pot, usedThemes }: Props) {
       </div>
 
       {/* Total Saved */}
-
       <div className="mb-400 flex items-center justify-between">
         <p className="text-preset-4 text-gray-500">Total Saved</p>
         <p className="text-preset-1 text-grey-900">{fmt(total)}</p>
@@ -51,20 +55,30 @@ export function PotCard({ pot, usedThemes }: Props) {
             aria-valuenow={Math.round(progress)}
             aria-valuemin={0}
             aria-valuemax={100}
-            aria-label={`${Math.round(progress)}% of budget spent`}
+            aria-label={`${Math.round(progress)}% of target saved`}
           />
         </div>
         <div className="flex items-center justify-between">
-          <p className="text-preset-5-bold text-gray-500">{progress}%</p>
+          <p className="text-preset-5-bold text-gray-500">
+            {progress.toFixed(2)}%
+          </p>
           <p className="text-preset-5 text-grey-500">Target of {fmt(target)}</p>
         </div>
       </div>
 
       {/* Footer */}
       <div className="flex gap-400">
-        <Button variant="secondary">+ Add Money</Button>
+        <Button variant="secondary" onClick={() => setAddMoneyOpen(true)}>
+          + Add Money
+        </Button>
         <Button variant="secondary">Withdraw</Button>
       </div>
+
+      <AddMoneyModal
+        pot={pot}
+        open={addMoneyOpen}
+        onOpenChange={setAddMoneyOpen}
+      />
     </div>
   );
 }

--- a/src/app/(dashboard)/pots/_components/PotCard.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCard.tsx
@@ -23,6 +23,7 @@ export function PotCard({ pot, usedThemes }: Props) {
   const themeColor = THEME_COLORS[theme];
   const progress = Math.min(100, (total / target) * 100);
   const [addMoneyOpen, setAddMoneyOpen] = useState(false);
+  const isFull = total >= target;
 
   return (
     <div className="rounded-2xl bg-white p-500">
@@ -68,7 +69,11 @@ export function PotCard({ pot, usedThemes }: Props) {
 
       {/* Footer */}
       <div className="flex gap-400">
-        <Button variant="secondary" onClick={() => setAddMoneyOpen(true)}>
+        <Button
+          variant="secondary"
+          onClick={() => setAddMoneyOpen(true)}
+          disabled={isFull}
+        >
           + Add Money
         </Button>
         <Button variant="secondary">Withdraw</Button>

--- a/src/server/actions/pots.ts
+++ b/src/server/actions/pots.ts
@@ -6,44 +6,57 @@ import { auth } from "@/lib/auth/auth";
 import { prisma } from "@/lib/db/prisma";
 import { Theme } from "@/generated/prisma/enums";
 
+const potNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(30, "Name must be 30 characters or less");
+
+const potTargetSchema = z.number().positive("Target must be greater than zero");
+
 const createPotSchema = z.object({
-  name: z
-    .string()
-    .min(1, "Name is required")
-    .max(30, "Name must be 30 characters or less"),
-  target: z.number().positive("Target must be greater than zero"),
+  name: potNameSchema,
+  target: potTargetSchema,
   theme: z.enum(Theme),
 });
 
-export type CreatePotInput = z.infer<typeof createPotSchema>;
+const updatePotSchema = z.object({
+  id: z.string().min(1),
+  name: potNameSchema,
+  target: potTargetSchema,
+  theme: z.enum(Theme),
+});
 
-export type CreatePotResult =
+const addMoneySchema = z.object({
+  id: z.string().min(1),
+  amount: z.number().positive("Amount must be greater than zero"),
+});
+
+export type CreatePotInput = z.infer<typeof createPotSchema>;
+export type UpdatePotInput = z.infer<typeof updatePotSchema>;
+export type AddMoneyInput = z.infer<typeof addMoneySchema>;
+
+export type PotActionResult =
   | { success: true }
-  | {
-      success: false;
-      fieldErrors?: Partial<Record<keyof CreatePotInput, string[]>>;
-    };
+  | { success: false; error?: string; fieldErrors?: Record<string, string[]> };
 
 export async function createPot(
   input: CreatePotInput,
-): Promise<CreatePotResult> {
+): Promise<PotActionResult> {
   const session = await auth();
-  if (!session?.user?.id) {
-    throw new Error("Unauthorized");
-  }
+  if (!session?.user?.id) throw new Error("Unauthorized");
 
   const parsed = createPotSchema.safeParse(input);
   if (!parsed.success) {
     return {
       success: false,
-      fieldErrors: z.flattenError(parsed.error).fieldErrors as Partial<
-        Record<keyof CreatePotInput, string[]>
+      fieldErrors: z.flattenError(parsed.error).fieldErrors as Record<
+        string,
+        string[]
       >,
     };
   }
 
   const { name, target, theme } = parsed.data;
-
   await prisma.pot.create({
     data: { name, target, theme, userId: session.user.id },
   });
@@ -51,18 +64,6 @@ export async function createPot(
   revalidatePath("/pots");
   return { success: true };
 }
-
-const updatePotSchema = z.object({
-  id: z.string().min(1),
-  name: z
-    .string()
-    .min(1, "Name is required")
-    .max(30, "Name must be 30 characters or less"),
-  target: z.number().positive("Target must be greater than zero"),
-  theme: z.enum(Theme),
-});
-
-export type UpdatePotInput = z.infer<typeof updatePotSchema>;
 
 export type UpdatePotResult =
   | { success: true }
@@ -90,7 +91,6 @@ export async function updatePot(
   }
 
   const { id, name, target, theme } = parsed.data;
-
   await prisma.pot.update({
     where: { id, userId: session.user.id },
     data: { name, target, theme },

--- a/src/server/actions/pots.ts
+++ b/src/server/actions/pots.ts
@@ -113,3 +113,45 @@ export async function deletePot(id: string): Promise<{ success: true }> {
   revalidatePath("/pots");
   return { success: true };
 }
+
+export type AddMoneyResult =
+  | { success: true }
+  | { success: false; error?: string };
+
+export async function addMoneyToPot(
+  input: AddMoneyInput,
+): Promise<AddMoneyResult> {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error("Unauthorized");
+
+  const parsed = addMoneySchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message,
+    };
+  }
+
+  const { id, amount } = parsed.data;
+
+  const pot = await prisma.pot.findFirst({
+    where: { id, userId: session.user.id },
+  });
+
+  if (!pot) throw new Error("Pot not found");
+
+  if (pot.total + amount > pot.target) {
+    return {
+      success: false,
+      error: `Amount exceeds target. You can add at most $${(pot.target - pot.total).toFixed(2)}.`,
+    };
+  }
+
+  await prisma.pot.update({
+    where: { id },
+    data: { total: { increment: amount } },
+  });
+
+  revalidatePath("/pots");
+  return { success: true };
+}


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->
- Adds `addMoneyToPot` server action that validates the amount against the pot's target, then atomically increments `total` via Prisma `increment`
- Adds `AddMoneyModal` with live two-segment progress bar preview (dark = existing total, theme color = new addition) and real-time "New Amount" display
- Disables the "Add Money" button on `PotCard` when the pot is already full (`total >= target`)

## Acceptance criteria

## 🔗 Related issue

Closes #52 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1. Add money to a pot with available space — confirm total updates and progress bar reflects it
2. Type an amount that would exceed the target — confirm error message appears and button stays disabled
3. Open a pot that is 100% full — confirm Add Money button is disabled
4. Submit with empty or zero amount — confirm validation error

## ✅ Checklist

- [ ] My code follows the project conventions
- [ ] I reviewed my own code
- [ ] I added / updated tests
- [ ] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
<img width="1429" height="832" alt="Screenshot 2026-05-27 at 06 41 47" src="https://github.com/user-attachments/assets/1314b83e-fb1d-403b-b454-2888271148fb" />
<img width="1429" height="832" alt="Screenshot 2026-05-27 at 06 41 40" src="https://github.com/user-attachments/assets/f8887a02-adf8-4fe9-b8a0-22a58b5734c0" />
