### PR TITLE
test: FIN-66 - Testes de pots

### DIFF
--- a/src/app/(dashboard)/pots/_components/PotCard.test.tsx
+++ b/src/app/(dashboard)/pots/_components/PotCard.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PotCard } from "./PotCard";
+import type { PotModel as Pot } from "@/generated/prisma/models";
+
+vi.mock("./PotCardActions", () => ({ PotCardActions: () => null }));
+vi.mock("./AddMoneyModal", () => ({ AddMoneyModal: () => null }));
+vi.mock("./WithdrawMoneyModal", () => ({ WithdrawMoneyModal: () => null }));
+
+const BASE_POT: Pot = {
+  id: "pot-1",
+  name: "Savings",
+  target: 2000,
+  total: 500,
+  theme: "Green",
+  userId: "user-1",
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+function renderCard(total: number, target = BASE_POT.target) {
+  return render(
+    <PotCard pot={{ ...BASE_POT, total, target }} usedThemes={["Green"]} />,
+  );
+}
+
+describe("PotCard — total saved display", () => {
+  it("displays the correct total saved", () => {
+    renderCard(500);
+    expect(screen.getByText("$500.00")).toBeInTheDocument();
+  });
+
+  it("displays the correct target", () => {
+    renderCard(500, 2000);
+    expect(screen.getByText("Target of $2,000.00")).toBeInTheDocument();
+  });
+});
+
+describe("PotCard — progress bar", () => {
+  it("sets aria-valuenow to the correct percentage", () => {
+    renderCard(1000, 2000);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "50");
+  });
+
+  it("caps aria-valuenow at 100 when total exceeds target", () => {
+    renderCard(2500, 2000);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "100");
+  });
+
+  it("shows 0% when total is zero", () => {
+    renderCard(0, 2000);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("shows 100% when total equals target", () => {
+    renderCard(2000, 2000);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "100");
+  });
+});
+
+describe("PotCard — Add Money button", () => {
+  it("is enabled when total is below target", () => {
+    renderCard(500, 2000);
+    const btn = screen.getByRole("button", { name: /add money/i });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("is disabled when total equals target (pot is full)", () => {
+    renderCard(2000, 2000);
+    const btn = screen.getByRole("button", { name: /add money/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("is disabled when total exceeds target", () => {
+    renderCard(2500, 2000);
+    const btn = screen.getByRole("button", { name: /add money/i });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/src/server/actions/pots.test.ts
+++ b/src/server/actions/pots.test.ts
@@ -1,0 +1,434 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPot,
+  updatePot,
+  deletePot,
+  addMoneyToPot,
+  withdrawFromPot,
+} from "./pots";
+
+vi.mock("@/lib/auth/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    pot: {
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { auth } from "@/lib/auth/auth";
+import { prisma } from "@/lib/db/prisma";
+import { revalidatePath } from "next/cache";
+
+const mockAuth = vi.mocked(auth);
+const mockCreate = vi.mocked(prisma.pot.create);
+const mockUpdate = vi.mocked(prisma.pot.update);
+const mockDelete = vi.mocked(prisma.pot.delete);
+const mockFindFirst = vi.mocked(prisma.pot.findFirst);
+const mockRevalidatePath = vi.mocked(revalidatePath);
+
+const VALID_CREATE_INPUT = {
+  name: "Savings",
+  target: 2000,
+  theme: "Green" as const,
+};
+
+const VALID_UPDATE_INPUT = {
+  id: "pot-1",
+  name: "Emergency Fund",
+  target: 5000,
+  theme: "Blue" as const,
+};
+
+const BASE_POT = {
+  id: "pot-1",
+  name: "Savings",
+  target: 2000,
+  total: 500,
+  theme: "Green" as const,
+  userId: "user-1",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function authenticated(userId = "user-1") {
+  mockAuth.mockResolvedValue({
+    user: { id: userId },
+  } as unknown as Awaited<ReturnType<typeof auth>>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreate.mockResolvedValue({} as never);
+  mockUpdate.mockResolvedValue({} as never);
+  mockDelete.mockResolvedValue({} as never);
+  mockFindFirst.mockResolvedValue(BASE_POT as never);
+});
+
+// ─── createPot ───────────────────────────────────────────────────────────────
+
+describe("createPot", () => {
+  describe("authentication", () => {
+    it("throws when not authenticated", async () => {
+      mockAuth.mockResolvedValue(null as never);
+      await expect(createPot(VALID_CREATE_INPUT)).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+
+    it("throws when session has no user id", async () => {
+      mockAuth.mockResolvedValue({ user: {} } as never);
+      await expect(createPot(VALID_CREATE_INPUT)).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+  });
+
+  describe("validation — name", () => {
+    it("returns error when name is empty", async () => {
+      authenticated();
+      const result = await createPot({ ...VALID_CREATE_INPUT, name: "" });
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { name: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+
+    it("returns error when name exceeds 30 characters", async () => {
+      authenticated();
+      const result = await createPot({
+        ...VALID_CREATE_INPUT,
+        name: "A".repeat(31),
+      });
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { name: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+
+    it("accepts a name with exactly 30 characters", async () => {
+      authenticated();
+      const result = await createPot({
+        ...VALID_CREATE_INPUT,
+        name: "A".repeat(30),
+      });
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe("validation — target", () => {
+    it("returns error when target is zero", async () => {
+      authenticated();
+      const result = await createPot({ ...VALID_CREATE_INPUT, target: 0 });
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { target: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+
+    it("returns error when target is negative", async () => {
+      authenticated();
+      const result = await createPot({ ...VALID_CREATE_INPUT, target: -100 });
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { target: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+  });
+
+  describe("success", () => {
+    it("creates the pot scoped to the authenticated user", async () => {
+      authenticated("user-42");
+      await createPot(VALID_CREATE_INPUT);
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: {
+          name: "Savings",
+          target: 2000,
+          theme: "Green",
+          userId: "user-42",
+        },
+      });
+    });
+
+    it("revalidates /pots", async () => {
+      authenticated();
+      await createPot(VALID_CREATE_INPUT);
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/pots");
+    });
+
+    it("returns { success: true }", async () => {
+      authenticated();
+      const result = await createPot(VALID_CREATE_INPUT);
+      expect(result).toEqual({ success: true });
+    });
+
+    it("does not call prisma when validation fails", async () => {
+      authenticated();
+      await createPot({ ...VALID_CREATE_INPUT, target: 0 });
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ─── updatePot ───────────────────────────────────────────────────────────────
+
+describe("updatePot", () => {
+  describe("authentication", () => {
+    it("throws when not authenticated", async () => {
+      mockAuth.mockResolvedValue(null as never);
+      await expect(updatePot(VALID_UPDATE_INPUT)).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+  });
+
+  describe("validation — name", () => {
+    it("returns error when name exceeds 30 characters", async () => {
+      authenticated();
+      const result = await updatePot({
+        ...VALID_UPDATE_INPUT,
+        name: "A".repeat(31),
+      });
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { name: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+  });
+
+  describe("validation — target", () => {
+    it("returns error when target is zero", async () => {
+      authenticated();
+      const result = await updatePot({ ...VALID_UPDATE_INPUT, target: 0 });
+      expect(result).toMatchObject({
+        success: false,
+        fieldErrors: { target: expect.arrayContaining([expect.any(String)]) },
+      });
+    });
+  });
+
+  describe("success", () => {
+    it("updates scoped to the authenticated user", async () => {
+      authenticated("user-99");
+      await updatePot(VALID_UPDATE_INPUT);
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: "pot-1", userId: "user-99" },
+        data: { name: "Emergency Fund", target: 5000, theme: "Blue" },
+      });
+    });
+
+    it("revalidates /pots", async () => {
+      authenticated();
+      await updatePot(VALID_UPDATE_INPUT);
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/pots");
+    });
+  });
+});
+
+// ─── deletePot ───────────────────────────────────────────────────────────────
+
+describe("deletePot", () => {
+  describe("authentication", () => {
+    it("throws when not authenticated", async () => {
+      mockAuth.mockResolvedValue(null as never);
+      await expect(deletePot("pot-1")).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("success", () => {
+    it("deletes scoped to the authenticated user", async () => {
+      authenticated("user-7");
+      await deletePot("pot-1");
+      expect(mockDelete).toHaveBeenCalledWith({
+        where: { id: "pot-1", userId: "user-7" },
+      });
+    });
+
+    it("revalidates /pots", async () => {
+      authenticated();
+      await deletePot("pot-1");
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/pots");
+    });
+
+    it("returns { success: true }", async () => {
+      authenticated();
+      const result = await deletePot("pot-1");
+      expect(result).toEqual({ success: true });
+    });
+  });
+});
+
+// ─── addMoneyToPot ───────────────────────────────────────────────────────────
+
+describe("addMoneyToPot", () => {
+  describe("authentication", () => {
+    it("throws when not authenticated", async () => {
+      mockAuth.mockResolvedValue(null as never);
+      await expect(addMoneyToPot({ id: "pot-1", amount: 100 })).rejects.toThrow(
+        "Unauthorized",
+      );
+    });
+  });
+
+  describe("validation — amount", () => {
+    it("returns error when amount is zero", async () => {
+      authenticated();
+      const result = await addMoneyToPot({ id: "pot-1", amount: 0 });
+      expect(result).toMatchObject({ success: false });
+    });
+
+    it("returns error when amount is negative", async () => {
+      authenticated();
+      const result = await addMoneyToPot({ id: "pot-1", amount: -50 });
+      expect(result).toMatchObject({ success: false });
+    });
+  });
+
+  describe("business rules", () => {
+    it("returns error when amount would exceed target", async () => {
+      authenticated();
+      // pot has total=500, target=2000 → max addable = 1500
+      const result = await addMoneyToPot({ id: "pot-1", amount: 1501 });
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.any(String),
+      });
+    });
+
+    it("returns error when pot is already full (total === target)", async () => {
+      authenticated();
+      mockFindFirst.mockResolvedValueOnce({
+        ...BASE_POT,
+        total: 2000,
+      } as never);
+      const result = await addMoneyToPot({ id: "pot-1", amount: 1 });
+      expect(result).toMatchObject({ success: false });
+    });
+
+    it("allows adding exactly the remaining amount", async () => {
+      authenticated();
+      // total=500, target=2000 → can add exactly 1500
+      const result = await addMoneyToPot({ id: "pot-1", amount: 1500 });
+      expect(result).toEqual({ success: true });
+    });
+
+    it("throws when pot is not found", async () => {
+      authenticated();
+      mockFindFirst.mockResolvedValueOnce(null as never);
+      await expect(addMoneyToPot({ id: "pot-1", amount: 100 })).rejects.toThrow(
+        "Pot not found",
+      );
+    });
+  });
+
+  describe("success", () => {
+    it("increments total by the given amount", async () => {
+      authenticated();
+      await addMoneyToPot({ id: "pot-1", amount: 200 });
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: "pot-1" },
+        data: { total: { increment: 200 } },
+      });
+    });
+
+    it("revalidates /pots", async () => {
+      authenticated();
+      await addMoneyToPot({ id: "pot-1", amount: 100 });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/pots");
+    });
+
+    it("returns { success: true }", async () => {
+      authenticated();
+      const result = await addMoneyToPot({ id: "pot-1", amount: 100 });
+      expect(result).toEqual({ success: true });
+    });
+  });
+});
+
+// ─── withdrawFromPot ─────────────────────────────────────────────────────────
+
+describe("withdrawFromPot", () => {
+  describe("authentication", () => {
+    it("throws when not authenticated", async () => {
+      mockAuth.mockResolvedValue(null as never);
+      await expect(
+        withdrawFromPot({ id: "pot-1", amount: 100 }),
+      ).rejects.toThrow("Unauthorized");
+    });
+  });
+
+  describe("validation — amount", () => {
+    it("returns error when amount is zero", async () => {
+      authenticated();
+      const result = await withdrawFromPot({ id: "pot-1", amount: 0 });
+      expect(result).toMatchObject({ success: false });
+    });
+
+    it("returns error when amount is negative", async () => {
+      authenticated();
+      const result = await withdrawFromPot({ id: "pot-1", amount: -50 });
+      expect(result).toMatchObject({ success: false });
+    });
+  });
+
+  describe("business rules — balance cannot go negative", () => {
+    it("returns error when amount exceeds current total", async () => {
+      authenticated();
+      // pot has total=500 → cannot withdraw 501
+      const result = await withdrawFromPot({ id: "pot-1", amount: 501 });
+      expect(result).toMatchObject({
+        success: false,
+        error: expect.any(String),
+      });
+    });
+
+    it("returns error when pot has zero total", async () => {
+      authenticated();
+      mockFindFirst.mockResolvedValueOnce({ ...BASE_POT, total: 0 } as never);
+      const result = await withdrawFromPot({ id: "pot-1", amount: 1 });
+      expect(result).toMatchObject({ success: false });
+    });
+
+    it("allows withdrawing exactly the current total", async () => {
+      authenticated();
+      // total=500 → can withdraw exactly 500
+      const result = await withdrawFromPot({ id: "pot-1", amount: 500 });
+      expect(result).toEqual({ success: true });
+    });
+
+    it("throws when pot is not found", async () => {
+      authenticated();
+      mockFindFirst.mockResolvedValueOnce(null as never);
+      await expect(
+        withdrawFromPot({ id: "pot-1", amount: 100 }),
+      ).rejects.toThrow("Pot not found");
+    });
+  });
+
+  describe("success", () => {
+    it("decrements total by the given amount", async () => {
+      authenticated();
+      await withdrawFromPot({ id: "pot-1", amount: 200 });
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: "pot-1" },
+        data: { total: { decrement: 200 } },
+      });
+    });
+
+    it("revalidates /pots", async () => {
+      authenticated();
+      await withdrawFromPot({ id: "pot-1", amount: 100 });
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/pots");
+    });
+
+    it("returns { success: true }", async () => {
+      authenticated();
+      const result = await withdrawFromPot({ id: "pot-1", amount: 100 });
+      expect(result).toEqual({ success: true });
+    });
+  });
+});


### PR DESCRIPTION
## 📋 Description

<!-- Briefly describe what was done in this PR -->

Adds unit tests for all pot server actions and the PotCard component (FIN-66), and extracts a shared `formatAmount` utility to eliminate duplicated `Intl.NumberFormat` calls across 5 components.

## 🔗 Related issue

Closes #54 

<!-- Use "Closes", "Fixes" or "Resolves" to automatically close the issue on merge -->
<!-- Examples:
  Closes #42
  Fixes #42
  Resolves #42
-->

## 🔄 Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [x] 🧪 Tests

## 🧪 How to test

<!-- Step-by-step instructions to test the changes -->

1.
2.
3.

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I reviewed my own code
- [x] I added / updated tests
- [x] Existing tests pass locally
- [ ] I updated the documentation (if applicable)

## 📸 Screenshots (if applicable)

<!-- Paste screenshots or gifs here -->
